### PR TITLE
hides disqus on auth

### DIFF
--- a/src/routes/sessions/SessionDetails.svelte
+++ b/src/routes/sessions/SessionDetails.svelte
@@ -148,10 +148,8 @@
     </div>
   </div>
 
-  {#if $isAuthenticated}
-    <div class="px-4 py-12 sm:px-6">
-      <div id="disqus_thread"></div>
-    </div>
-  {/if}
+  <div class="px-4 py-12 sm:px-6" class:hidden="{!$isAuthenticated}">
+    <div id="disqus_thread"></div>
+  </div>
 
 </div>


### PR DESCRIPTION
Rather than removing the element which was causing other issues with their plugin, we just hide it if the user isn't authenticated.

closes #43 