### PR TITLE
enables social icons for session details

### DIFF
--- a/src/components/social/SocialLink.svelte
+++ b/src/components/social/SocialLink.svelte
@@ -1,0 +1,65 @@
+<script>
+  import Icon from 'svelte-awesome';
+  import {
+    link,
+    linkedin,
+    facebook,
+    twitter,
+    instagram,
+    github,
+    youtubePlay,
+    twitch,
+    dribbble,
+    medium,
+    stackOverflow,
+  } from 'svelte-awesome/icons';
+
+  export let network;
+  export let href;
+
+  let socialIcon;
+
+  switch (network) {
+    case 'FACEBOOK':
+      socialIcon = facebook;
+      break;
+    case 'TWITTER':
+      socialIcon = twitter;
+      break;
+    case 'GITHUB':
+      socialIcon = github;
+      break;
+    case 'INSTAGRAM':
+      socialIcon = instagram;
+      break;
+    case 'WEBSITE':
+      socialIcon = link;
+      break;
+    case 'LINKEDIN':
+      socialIcon = linkedin;
+      break;
+    case 'YOUTUBE':
+      socialIcon = youtubePlay;
+      break;
+    case 'TWITCH':
+      socialIcon = twitch;
+      break;
+    case 'DRIBBBLE':
+      socialIcon = dribbble;
+      break;
+    case 'MEDIUM':
+      socialIcon = medium;
+      break;
+    case 'STACK_OVERFLOW':
+      socialIcon = stackOverflow;
+      break;
+  }
+</script>
+
+<a {href}>
+  <Icon
+    data="{socialIcon}"
+    class="-ml-1 mr-2 h-5 w-5 text-gray-400 hover:text-gray-700 focus:underline
+    transition ease-in-out duration-150"
+  />
+</a>

--- a/src/components/social/index.js
+++ b/src/components/social/index.js
@@ -1,0 +1,1 @@
+export { default as SocialLink } from './SocialLink.svelte';

--- a/src/elements/layouts/StackedLayout.svelte
+++ b/src/elements/layouts/StackedLayout.svelte
@@ -11,6 +11,8 @@
     <div class="max-w-7xl mx-auto pb-12 px-4 sm:px-6 lg:px-8">
       <div class="bg-white rounded-lg shadow px-5 py-6 sm:px-6">
         <slot name="body" />
+        <!-- default slot as fallback-->
+        <slot />
       </div>
     </div>
   </main>

--- a/src/routes/sessions/Session.svelte
+++ b/src/routes/sessions/Session.svelte
@@ -55,7 +55,7 @@
   <div slot="body">
     {#if $sessionQuery.fetching}
       <div class="flex items-center justify-center">
-        <FacebookLoader />
+        <FacebookLoader uniqueKey="loading" />
       </div>
     {:else if $sessionQuery.error || !$sessionQuery.data}
       <ModalError

--- a/src/routes/sessions/SessionDetails.svelte
+++ b/src/routes/sessions/SessionDetails.svelte
@@ -3,13 +3,20 @@
   import dayjs from 'dayjs';
   import Icon from 'svelte-awesome';
   import { Link } from 'yrv';
-  import { heart, signIn } from 'svelte-awesome/icons';
+  import {
+    heart,
+    signIn,
+    facebook,
+    twitter,
+    instagram,
+    github,
+  } from 'svelte-awesome/icons';
   import qs from 'query-string';
 
   import { isAuthenticated } from '../../utilities/security.js';
   import { LinkButton, Tag } from '../../elements';
+  import { SocialLink } from '../../components/social';
 
-  export let router;
   export let title;
   export let shortDescription;
   export let speakers;
@@ -72,6 +79,13 @@
             <h3 class="text-lg leading-6 font-medium text-gray-900">
               {`${host.firstName} ${host.lastName}`}
             </h3>
+
+            <div>
+              {#each host.profileLinks as link}
+                <SocialLink href="{link.url}" network="{link.linkType}" />
+              {/each}
+            </div>
+
           </div>
         </div>
       </div>


### PR DESCRIPTION
Adds the following:

![image](https://user-images.githubusercontent.com/772569/87339130-c5ad4300-c50b-11ea-810f-a6424fa26037.png)

Also fixes the default slot warning on stacked layout.

closes issue #35 