### PR TITLE
graph client creations happens in page

### DIFF
--- a/src/components/sessions/Card.svelte
+++ b/src/components/sessions/Card.svelte
@@ -11,7 +11,11 @@
   import config from '../../config';
   import { isAuthenticated } from '../../utilities/security';
   import { truncate } from '../../utilities/truncate';
-  import { toggleFavorite } from '../../dataSources/api.that.tech/favorites';
+  import favoritesApi from '../../dataSources/api.that.tech/favorites';
+
+  // const client = getClient();
+
+  const { toggleFavorite } = favoritesApi(getClient());
 
   // UI Elements
   import { Tag } from '../../elements';

--- a/src/dataSources/api.that.tech/favorites.js
+++ b/src/dataSources/api.that.tech/favorites.js
@@ -1,4 +1,3 @@
-import { getClient } from '@urql/svelte';
 import config from '../../config';
 
 const TOGGLE_FAVORITE = `
@@ -12,15 +11,6 @@ const TOGGLE_FAVORITE = `
     }
   }
 `;
-
-export const toggleFavorite = (eventId, sessionId) => {
-  const mutationVariables = {
-    eventId,
-    sessionId,
-  };
-
-  return getClient().mutation(TOGGLE_FAVORITE, mutationVariables).toPromise();
-};
 
 export const QUERY_MY_FAVORITES = `
   query memberFavorites ($eventId: ID!) {
@@ -45,13 +35,26 @@ export const QUERY_MY_FAVORITES = `
   }
 `;
 
-export const queryMyFavorites = () => {
-  const variables = {
-    eventId: config.eventId,
+export default (client) => {
+  const toggleFavorite = (eventId, sessionId) => {
+    const mutationVariables = {
+      eventId,
+      sessionId,
+    };
+
+    return client.mutation(TOGGLE_FAVORITE, mutationVariables).toPromise();
   };
 
-  return getClient()
-    .query(QUERY_MY_FAVORITES, variables)
-    .toPromise()
-    .then((r) => r.data.sessions.me.favorites);
+  const queryMyFavorites = () => {
+    const variables = {
+      eventId: config.eventId,
+    };
+
+    return client
+      .query(QUERY_MY_FAVORITES, variables)
+      .toPromise()
+      .then((r) => r.data.sessions.me.favorites);
+  };
+
+  return { toggleFavorite, queryMyFavorites };
 };

--- a/src/dataSources/api.that.tech/sessions.js
+++ b/src/dataSources/api.that.tech/sessions.js
@@ -1,4 +1,3 @@
-import { getClient } from '@urql/svelte';
 import config from '../../config';
 
 export const QUERY_SESSIONS = `
@@ -26,10 +25,14 @@ export const QUERY_SESSIONS = `
   }
 `;
 
-export const querySessions = () => {
-  const variables = { eventId: config.eventId };
-  return getClient()
-    .query(QUERY_SESSIONS, variables)
-    .toPromise()
-    .then((r) => r.data.events.event.get.sessions);
+export default (client) => {
+  const querySessions = () => {
+    const variables = { eventId: config.eventId };
+    return client
+      .query(QUERY_SESSIONS, variables)
+      .toPromise()
+      .then((r) => r.data.events.event.get.sessions);
+  };
+
+  return { querySessions };
 };

--- a/src/dataSources/api.that.tech/submissions.js
+++ b/src/dataSources/api.that.tech/submissions.js
@@ -1,4 +1,3 @@
-import { getClient } from '@urql/svelte';
 import config from '../../config';
 
 export const QUERY_SUBMISSIONS = `
@@ -29,16 +28,20 @@ export const QUERY_SUBMISSIONS = `
   }
 `;
 
-export const queryMySubmissions = () => {
-  const variables = { eventId: config.eventId };
-  return getClient()
-    .query(QUERY_SUBMISSIONS, variables)
-    .toPromise()
-    .then((r) => {
-      const { submitted } = r.data.sessions.me;
+export default (client) => {
+  const queryMySubmissions = () => {
+    const variables = { eventId: config.eventId };
+    return client
+      .query(QUERY_SUBMISSIONS, variables)
+      .toPromise()
+      .then((r) => {
+        const { submitted } = r.data.sessions.me;
 
-      return submitted
-        .filter((s) => s.type === 'OPEN_SPACE')
-        .filter((s) => s.eventId === config.eventId);
-    });
+        return submitted
+          .filter((s) => s.type === 'OPEN_SPACE')
+          .filter((s) => s.eventId === config.eventId);
+      });
+  };
+
+  return { queryMySubmissions };
 };

--- a/src/routes/my/Favorites.svelte
+++ b/src/routes/my/Favorites.svelte
@@ -1,15 +1,17 @@
 <script>
   export let router;
+  import { getClient } from '@urql/svelte';
 
   import Nav from '../../components/nav/Top.svelte';
   import StackedLayout from '../../elements/layouts/StackedLayout.svelte';
   import Sponsor from '../../components/SponsorSimple.svelte';
-
   import { ActionHeader, LinkButton } from '../../elements';
 
   import SessionsLoading from '../../components/sessions/SessionsLoading.svelte';
   import SessionsList from '../../components/sessions/List.svelte';
-  import { queryMyFavorites } from '../../dataSources/api.that.tech/favorites';
+  import favoritesApi from '../../dataSources/api.that.tech/favorites';
+
+  const { queryMyFavorites } = favoritesApi(getClient());
 
   const query = queryMyFavorites();
 </script>

--- a/src/routes/my/Submissions.svelte
+++ b/src/routes/my/Submissions.svelte
@@ -1,5 +1,6 @@
 <script>
   export let router;
+  import { getClient } from '@urql/svelte';
 
   import Nav from '../../components/nav/Top.svelte';
   import StackedLayout from '../../elements/layouts/StackedLayout.svelte';
@@ -9,8 +10,9 @@
 
   import SessionsLoading from '../../components/sessions/SessionsLoading.svelte';
   import SessionsList from '../../components/sessions/List.svelte';
-  import { queryMySubmissions } from '../../dataSources/api.that.tech/submissions';
+  import submissionsApi from '../../dataSources/api.that.tech/submissions';
 
+  const { queryMySubmissions } = submissionsApi(getClient());
   const query = queryMySubmissions();
 </script>
 

--- a/src/routes/sessions/List.svelte
+++ b/src/routes/sessions/List.svelte
@@ -1,4 +1,7 @@
 <script>
+  export let router;
+
+  import { getClient } from '@urql/svelte';
   import { Link } from 'yrv';
   import { onMount } from 'svelte';
 
@@ -8,11 +11,11 @@
   import SessionsList from '../../components/sessions/List.svelte';
   import SessionsLoading from '../../components/sessions/SessionsLoading.svelte';
 
-  import { querySessions } from '../../dataSources/api.that.tech/sessions';
+  import sessionsApi from '../../dataSources/api.that.tech/sessions';
   import { ActionHeader, LinkButton } from '../../elements';
   import StackedLayout from '../../elements/layouts/StackedLayout.svelte';
 
-  export let router;
+  const { querySessions } = sessionsApi(getClient());
 
   $: query = querySessions();
 


### PR DESCRIPTION
Rather than calling getClient in the js file abstraction over the API, we pass the client downwards to that abstraction. There is some lifecycle issue with getclient that causes a race condition when called there. 

valid workaround until we understand the lifecycle more.

closes #59 