### PR TITLE
set the page title to static data

### DIFF
--- a/src/routes/join/Live.svelte
+++ b/src/routes/join/Live.svelte
@@ -101,7 +101,7 @@
 </script>
 
 <svelte:head>
-  <title>{$sessionQuery.data.events.event.session.title} * THAT.us</title>
+  <title>Join * THAT.us</title>
   <script src="https://meet.jit.si/external_api.js" on:load="{initJitsi}">
 
   </script>


### PR DESCRIPTION
something is going on when trying to set the title in head.  just set it for static for now.