### PR TITLE
enable rotation refresh tokens

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@ export const securityConfig = {
   redirect_uri: 'http://localhost:5000/sessions',
   audience: 'https://api.that.tech/graphql',
   scope: 'openid profile email offline_access',
+  useRefreshTokens: true,
 };
 
 export default {


### PR DESCRIPTION
Doesn't completely correct Issue #121 but is an important setting for SPA pages. 