### PR TITLE
sets focus on the jitsi control

### DIFF
--- a/src/routes/join/Live.svelte
+++ b/src/routes/join/Live.svelte
@@ -106,6 +106,8 @@
           'displayName',
           `${$thatProfile.firstName} ${$thatProfile.lastName}`,
         );
+
+        api.getIFrame().focus();
       },
 
       parentNode: document.getElementById('meet'),


### PR DESCRIPTION
Set's default focus when the Jitsi control loads. That way we can automatically use the keyboard shortcuts offered by jitsi such as spacebar to unmute.

closes #199 