### PR TITLE
fixes new user social link check

### DIFF
--- a/src/components/my/ProfileForm.svelte
+++ b/src/components/my/ProfileForm.svelte
@@ -117,13 +117,15 @@
   function getInitialSocailLinkValue(link) {
     let result = '';
 
-    const [socialLink] = profile.profileLinks.filter(
-      i => i.linkType === link.linkType,
-    );
+    if (!isNewProfile && profile.profileLinks) {
+      const [socialLink] = profile.profileLinks.filter(
+        i => i.linkType === link.linkType,
+      );
 
-    if (socialLink) {
-      let [slug, value] = socialLink.url.split(link.slug);
-      result = value;
+      if (socialLink) {
+        let [slug, value] = socialLink.url.split(link.slug);
+        result = value;
+      }
     }
 
     return result;


### PR DESCRIPTION
When setting up the form, we checked the profile for social links to populate the input boxes but that array would be empty for a new user and the filter was blowing up.