### PR TITLE
redirect new user to signup rather than login

### DIFF
--- a/src/components/home/Hero.svelte
+++ b/src/components/home/Hero.svelte
@@ -67,14 +67,14 @@
             <div class="rounded-md shadow">
               <Link
                 open
-                href="http://tickets.thatconference.com"
+                href="/login?signup=true"
                 class="w-full flex items-center justify-center px-8 py-3 border
                 border-transparent text-base leading-6 font-medium rounded-md
                 text-white bg-indigo-600 hover:bg-indigo-500 focus:outline-none
                 focus:border-indigo-700 focus:shadow-outline-indigo transition
                 duration-150 ease-in-out md:py-4 md:text-lg md:px-10"
               >
-                Purchase Tickets
+                Sign Up
               </Link>
             </div>
 

--- a/src/routes/Login.svelte
+++ b/src/routes/Login.svelte
@@ -3,12 +3,15 @@
   export let documentReferrer = '/sessions';
 
   import { onMount } from 'svelte';
+  import qs from 'query-string';
 
   import { login } from '../utilities/security.js';
   import { ModalNoAction } from '../elements';
 
+  const { signup = false } = qs.parse(location.search);
+
   onMount(async () => {
-    await login(documentReferrer);
+    await login(documentReferrer, signup);
   });
 </script>
 

--- a/src/utilities/security.js
+++ b/src/utilities/security.js
@@ -24,7 +24,7 @@ export const logout = async () => {
   });
 };
 
-export const login = async (documentReferrer) => {
+export const login = async (documentReferrer, signup) => {
   const auth0 = await auth0Promise;
 
   const appState = {
@@ -32,10 +32,19 @@ export const login = async (documentReferrer) => {
     search: window.location.search,
   };
 
-  await auth0.loginWithRedirect({
+  let authParams = {
     redirect_uri: `${window.location.origin}/sessions`,
     appState,
-  });
+  };
+
+  if (signup) {
+    authParams = {
+      ...authParams,
+      screen_hint: 'signup',
+    };
+  }
+
+  await auth0.loginWithRedirect(authParams);
 };
 
 export async function generateAuth0() {


### PR DESCRIPTION
The Initial signup process is very confusing. In part because we were redirecting to login but the link for a new account is on the bottom of the login screen.

This updates the front page hero image from `purchase tickets` to `sign up`. That will redirect to our login component which in turn redirects to auth0. Rather than redirecting to auth0 login, we're not redirecting directly to a new user signup.

The ui in auth0 still needs some work.. but at least it takes you where you'd hope to go.