### PR TITLE
closes #282

### DIFF
--- a/src/dataSources/api.that.tech/sessions.js
+++ b/src/dataSources/api.that.tech/sessions.js
@@ -94,6 +94,36 @@ export const QUERY_SESSIONS = `
     }
   }
 `;
+export const QUERY_SESSIONS_BY_DATE = `
+  ${coreSessionFields}
+  query GetEventsSessions ($eventId: ID!, $onOrAfter: Date, $daysAfter: Int) {
+    events {
+      event(id: $eventId) {
+        get {
+          sessions(onOrAfter: $onOrAfter, daysAfter: $daysAfter) {
+            ...coreFields
+            speakers {
+              id
+              firstName
+              lastName
+              bio
+              jobTitle
+              company
+              profileImage
+              profileSlug
+              earnedMeritBadges {
+                id
+                name
+                image
+                description
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
 
 export const CREATE_SESSION = `
   ${coreOpenSpaceFields}
@@ -134,10 +164,9 @@ export const SET_ATTENDANCE = `
 `;
 
 export default (client) => {
-  const querySessions = (eventId, onOrAfter = new Date(), daysAfter = 30) => {
-    const variables = { eventId, onOrAfter, daysAfter };
-    return client
-      .query(QUERY_SESSIONS, variables)
+  const query = (graphQuery, variables) =>
+    client
+      .query(graphQuery, variables)
       .toPromise()
       .then((r) => {
         if (r.error) {
@@ -155,7 +184,14 @@ export default (client) => {
 
         return results;
       });
-  };
+
+  const querySessions = (eventId) => query(QUERY_SESSIONS, { eventId });
+
+  const querySessionsByDate = (
+    eventId,
+    onOrAfter = new Date(),
+    daysAfter = 30,
+  ) => query(QUERY_SESSIONS_BY_DATE, { eventId, onOrAfter, daysAfter });
 
   const queryAllEventsSessions = (eventId) => {
     const variables = { eventId };
@@ -251,6 +287,7 @@ export default (client) => {
 
   return {
     querySessions,
+    querySessionsByDate,
     queryAllEventsSessions,
     getById,
     create,

--- a/src/routes/sessions/List.svelte
+++ b/src/routes/sessions/List.svelte
@@ -28,7 +28,7 @@
   // stores
   import currentEvent from '../../store/currentEvent';
 
-  const { querySessions } = sessionsApi(getClient());
+  const { querySessionsByDate } = sessionsApi(getClient());
 
   let createDisabled = true;
 
@@ -68,7 +68,7 @@
     <div class="text-red-500 text-sm leading-5 text-right lowercase italic">
       <span>* Scheduled times are represented in your timezone.</span>
     </div>
-    {#await querySessions($currentEvent.eventId)}
+    {#await querySessionsByDate($currentEvent.eventId)}
       <CardLoader />
     {:then sessions}
       <SessionsList {sessions} />


### PR DESCRIPTION
We we not calling the correct query to filter out today forward. Query calls were refactored for usage across both, date and all, alone with updating the caller to call the correct query.


closes #282 