### PR TITLE
subtracts a day to return todays sessions

### DIFF
--- a/src/dataSources/api.that.tech/sessions.js
+++ b/src/dataSources/api.that.tech/sessions.js
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+
 const coreSessionFields = `
   fragment coreFields on AcceptedSession {
     id
@@ -191,7 +193,7 @@ export default (client) => {
 
   const querySessionsByDate = (
     eventId,
-    onOrAfter = new Date(),
+    onOrAfter = dayjs().subtract(1, 'day'),
     daysAfter = 30,
   ) =>
     query(


### PR DESCRIPTION
Updates the default to subtract a day as the starting point. Guessing there is more of an offset problem between the client and API but that also doesn't seem to align.

closes #287 

filed - https://github.com/ThatConference/that-api-events/issues/73