### PR TITLE
removes subtracting the day

### DIFF
--- a/src/dataSources/api.that.tech/sessions.js
+++ b/src/dataSources/api.that.tech/sessions.js
@@ -191,11 +191,7 @@ export default (client) => {
 
   const querySessions = (eventId) => query(QUERY_SESSIONS, { eventId });
 
-  const querySessionsByDate = (
-    eventId,
-    onOrAfter = dayjs().subtract(1, 'day'),
-    daysAfter = 30,
-  ) =>
+  const querySessionsByDate = (eventId, onOrAfter = dayjs(), daysAfter = 30) =>
     query(
       QUERY_SESSIONS_BY_DATE,
       { eventId, onOrAfter, daysAfter },


### PR DESCRIPTION
Undoes #287 as the session was marked wrong and was in the past. So it was working as built.

@brettski Mind you. I think we should look at the whole day and not just from that point in time. If a session is expired during that day, we should mark it so.

ref #282 #287 