### PR TITLE
fixes row break for session details

### DIFF
--- a/src/components/sessions/SessionDetails.svelte
+++ b/src/components/sessions/SessionDetails.svelte
@@ -178,7 +178,7 @@
   <div class="bg-white px-4 py-5 border-b border-gray-200 sm:px-6">
     <div
       class="-ml-4 -mt-4 flex justify-between items-center flex-wrap
-      sm:flex-no-wrap"
+      md:flex-no-wrap sm:flex-col lg:flex-row"
     >
       <div class="ml-4 mt-4">
         <div class="flex items-center">

--- a/src/routes/sessions/Session.svelte
+++ b/src/routes/sessions/Session.svelte
@@ -10,7 +10,7 @@
   // ui support
   import { ModalError, ActionHeader, LinkButton } from '../../elements';
   import Nav from '../../components/nav/interiorNav/Top.svelte';
-  import SessionDetails from './SessionDetails.svelte';
+  import SessionDetails from '../../components/sessions/SessionDetails.svelte';
   import StackedLayout from '../../elements/layouts/StackedLayout.svelte';
 
   // stores


### PR DESCRIPTION
building on #295 and what @Ghosts put through. Also changed the breaking point of the header to match what the session details was also already doing.

Smallest

![image](https://user-images.githubusercontent.com/772569/90899251-43773080-e38d-11ea-85e0-4b21a7ba6c62.png)

Small

![image](https://user-images.githubusercontent.com/772569/90899209-32c6ba80-e38d-11ea-8785-d512f838ef61.png)

Large

![image](https://user-images.githubusercontent.com/772569/90899310-55f16a00-e38d-11ea-8113-7b213b07fdec.png)
