### PR TITLE
just hides the note on smaller displays

### DIFF
--- a/src/components/sessions/List.svelte
+++ b/src/components/sessions/List.svelte
@@ -46,7 +46,7 @@
 <div>
   <h3
     class="sticky top-4 z-20 mr-4 text-thatRed-500 text-sm leading-5 text-right
-      lowercase italic"
+      lowercase italic invisible lg:visible"
   >
     <span>* Scheduled times are represented in your timezone.</span>
   </h3>


### PR DESCRIPTION
Right now we're just hiding the note on smaller displays. There really isn't a good place to put it and given the UI will most likely change, this felt like a path forward.

fixes #329 