### PR TITLE
updated link color to match the homepage

### DIFF
--- a/src/routes/releases/Missed.svelte
+++ b/src/routes/releases/Missed.svelte
@@ -58,7 +58,7 @@
         Since your last visit...
       </h3>
       <div>
-        <Link href="/changelog" class="pointer hover:text-thatBlue-500">
+        <Link href="/changelog" class="pointer text-thatOrange-400 hover:text-thatOrange-500">
           Checkout our past releases.
         </Link>
       </div>


### PR DESCRIPTION
Updates link color to match the color scheme for links on the home page.

fixes #328 