### PR TITLE
adds tidio api check before calling track

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,9 +1,9 @@
 <script>
   import { onMount, onDestroy } from 'svelte';
+  import { get } from 'svelte/store';
   import { initClient } from '@urql/svelte';
   import { navigateTo, router, Router, Route } from 'yrv';
   import { v4 as uuidv4 } from 'uuid';
-  import { get } from 'svelte/store';
 
   import {
     isAuthenticated,
@@ -68,9 +68,9 @@
 
   let documentReferrer;
 
-  function shouldRedirecToLogin() {
+  function isLoggedIn() {
     documentReferrer = window.location.pathname;
-    return $isAuthenticated;
+    return get(isAuthenticated);
   }
 
   router.subscribe(e => {
@@ -180,7 +180,7 @@
       exact
       path="/sessions/create"
       component="{Create}"
-      condition="{shouldRedirecToLogin}"
+      condition="{isLoggedIn}"
       redirect="/login"
     />
 
@@ -188,7 +188,7 @@
       exact
       path="/sessions/edit/:sessionId"
       component="{EditSession}"
-      condition="{shouldRedirecToLogin}"
+      condition="{isLoggedIn}"
       redirect="/login"
     />
 
@@ -199,7 +199,7 @@
       exact
       path="/join/:sessionId"
       component="{Live}"
-      condition="{shouldRedirecToLogin}"
+      condition="{isLoggedIn}"
       redirect="/login"
     />
 
@@ -207,7 +207,7 @@
       exact
       path="/my/favorites"
       component="{MyFavorites}"
-      condition="{shouldRedirecToLogin}"
+      condition="{isLoggedIn}"
       redirect="/login"
     />
 
@@ -215,7 +215,7 @@
       exact
       path="/my/submissions"
       component="{MySubmissions}"
-      condition="{shouldRedirecToLogin}"
+      condition="{isLoggedIn}"
       redirect="/login"
     />
 
@@ -223,7 +223,7 @@
       exact
       path="/my/profile"
       component="{Profile}"
-      condition="{shouldRedirecToLogin}"
+      condition="{isLoggedIn}"
       redirect="/login"
     />
 
@@ -231,7 +231,7 @@
       exact
       path="/my/badges"
       component="{Badges}"
-      condition="{shouldRedirecToLogin}"
+      condition="{isLoggedIn}"
       redirect="/login"
     />
 

--- a/src/routes/my/Badges.svelte
+++ b/src/routes/my/Badges.svelte
@@ -14,6 +14,7 @@
 
   // utilities
   import metaTagsStore from '../../store/metaTags';
+  import logEvent from '../../utilities/eventTrack';
   import { tagEvent } from '../../utilities/gtag';
 
   import {
@@ -43,7 +44,8 @@
 
     if (badgeEarned) {
       tagEvent('badgeClaimed', 'account', badgeEarned.id);
-      window.tidioChatApi.track('badge_claimed');
+
+      logEvent('badge_claimed');
 
       awardedBadge = badgeEarned;
 

--- a/src/routes/my/Profile.svelte
+++ b/src/routes/my/Profile.svelte
@@ -11,6 +11,7 @@
 
   import memberApi from '../../dataSources/api.that.tech/members.js';
   import { tagEvent } from '../../utilities/gtag';
+  import logEvent from '../../utilities/eventTrack';
   import metaTagsStore from '../../store/metaTags';
 
   import {
@@ -44,7 +45,7 @@
 
     thatProfile.set(updateResults);
     tagEvent('profile_created', 'account', $user.sub);
-    window.tidioChatApi.track('profile_created');
+    logEvent('profile_created');
 
     setSubmitting(false);
     resetForm();
@@ -68,7 +69,7 @@
     const updateResults = await updateProfile(updatedProfile);
 
     tagEvent('profile_update', 'account', $user.sub);
-    window.tidioChatApi.track('profile_update');
+    logEvent('profile_update');
 
     thatProfile.set(updateResults);
 

--- a/src/routes/sessions/Create.svelte
+++ b/src/routes/sessions/Create.svelte
@@ -19,6 +19,7 @@
   // utilities
   import metaTagsStore from '../../store/metaTags';
   import { tagEvent } from '../../utilities/gtag';
+  import logEvent from '../../utilities/eventTrack';
   import { format } from './formatRequest';
   import { user } from '../../utilities/security.js';
 
@@ -33,7 +34,7 @@
     const { id } = await create(newSession, $currentEvent.eventId);
 
     tagEvent('session_created', 'session', $user.sub);
-    window.tidioChatApi.track('session_created');
+    logEvent('session_created');
 
     setSubmitting(false);
     navigateTo(`/sessions/${id}?edit=true&isNew=true`, { replace: true });

--- a/src/routes/sessions/Edit.svelte
+++ b/src/routes/sessions/Edit.svelte
@@ -14,6 +14,7 @@
   // utilities
   import metaTagsStore from '../../store/metaTags';
   import { tagEvent } from '../../utilities/gtag';
+  import logEvent from '../../utilities/eventTrack';
   import { user } from '../../utilities/security.js';
   import { format } from './formatRequest';
 
@@ -31,7 +32,7 @@
     });
 
     tagEvent('session_withdraw', 'session', $user.sub);
-    window.tidioChatApi.track('session_withdraw');
+    logEvent('session_withdraw');
 
     navigateTo(`/my/submissions`, { replace: true });
   }
@@ -43,7 +44,7 @@
     await update(sessionId, updatedSession);
 
     tagEvent('session_update', 'session', $user.sub);
-    window.tidioChatApi.track('session_updated');
+    logEvent('session_updated');
 
     setSubmitting(false);
     resetForm();

--- a/src/utilities/eventTrack.js
+++ b/src/utilities/eventTrack.js
@@ -1,0 +1,5 @@
+function track(eventName) {
+  if (window.tidioChatApi) window.tidioChatApi.track(eventName);
+}
+
+export default track;

--- a/src/utilities/security.js
+++ b/src/utilities/security.js
@@ -5,6 +5,7 @@ import createAuth0Client from '@auth0/auth0-spa-js';
 import { getClient } from '@urql/svelte';
 import { navigateTo } from 'yrv';
 
+import logEvent from './eventTrack';
 import { securityConfig } from '../config';
 import meApi from '../dataSources/api.that.tech/me';
 
@@ -19,7 +20,7 @@ export const auth0Promise = createAuth0Client(securityConfig);
 export const logout = async () => {
   const auth0 = await auth0Promise;
 
-  window.tidioChatApi.track('logout');
+  logEvent('logout');
 
   await auth0.logout({
     returnTo: window.location.origin,
@@ -27,8 +28,6 @@ export const logout = async () => {
 };
 
 export const login = async (documentReferrer, signup) => {
-  window.tidioChatApi.track('login');
-
   const auth0 = await auth0Promise;
 
   const appState = {
@@ -48,6 +47,7 @@ export const login = async (documentReferrer, signup) => {
     };
   }
 
+  logEvent('login');
   await auth0.loginWithRedirect(authParams);
 };
 


### PR DESCRIPTION
Tidio track event wasn't checking if the api was in fact loaded already. To fix, wrapped with an event tracker, which checks to see if it's already loaded in window before calling.


fixing regression added in #348 