### PR TITLE
increase padding inside the Nav component parent

### DIFF
--- a/src/elements/layouts/_NavWrapper.svelte
+++ b/src/elements/layouts/_NavWrapper.svelte
@@ -6,7 +6,7 @@
   <div class="mx-auto">
     <div
       class="relative z-10 pb-4 bg-white sm:pb-8 md:pb-10 lg:max-w-2xl lg:w-full
-        lg:pb-12 xl:pb-16"
+        lg:pb-20 xl:pb-24"
     >
       <Nav />
     </div>


### PR DESCRIPTION
My first PR so any help is very welcome.

Apparently the problem happens because `Nav` has a fixed position and its parent doesn't have a set height, only padding.
From what I researched it's not possible to use auto height on the parent of a fixed/absolute positioned child, [see here](https://stackoverflow.com/questions/9061520/auto-height-on-parent-container-with-absolute-fixed-children).  
So the solution was to just **increase the padding value**. (I also tried removing the `overflow-hidden` class from the parent and it worked, but I didn't know which way was better)

**How it looks in Safari**
![safari resize](https://user-images.githubusercontent.com/51180770/94981953-0b771780-050d-11eb-809f-d73c3493eba1.gif)

**How it looks in Chrome**
![chrome resize](https://user-images.githubusercontent.com/51180770/94981962-16ca4300-050d-11eb-901a-5bfd647d0809.gif)

fixes #384 