### PR TITLE
move from onMount to tidio's onReady

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -111,15 +111,17 @@
         },
       ]);
     }
-    // Fixing Tidio Overlay
-    setTimeout(function () {
-      document.getElementById('tidio-chat-iframe').style.zIndex = '2';
-    }, 2500);
   });
 
   onDestroy(unsub);
 
   function onTidioChatApiReady() {
+        /*
+      resets the z-index of the tidio iframe such that it's under warnings.
+      ... we might have to set it better based on some other layering going on in places.
+    */
+    document.getElementById('tidio-chat-iframe').style.zIndex = '2';
+    
     unsub = thatProfile.subscribe(currentUser => {
       if (currentUser.id) {
         window.tidioChatApi.setVisitorData({


### PR DESCRIPTION
in issue #391 I had asked for the have the z-index update to be in the onMount. Really we should have just added that to the onReady event that tidio already has and that we're already wired too.

and because of that, we can remove the set timeout.

closes #396 