### PR TITLE
rolled back infinite scroll to working version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11276,9 +11276,9 @@
       "dev": true
     },
     "svelte-infinite-scroll": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/svelte-infinite-scroll/-/svelte-infinite-scroll-1.5.0.tgz",
-      "integrity": "sha512-e+MFRZWCgLbR9HkFnD+6pfYx98EJptzjnuB+efePd0YJRB7tfdOW/XdHfXUky0Prnq/KFjcdnIJGl9PjuWGXdg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/svelte-infinite-scroll/-/svelte-infinite-scroll-1.4.0.tgz",
+      "integrity": "sha512-Iezoxj24argq/iF6uCW9XN5dM3B7xgSzpUTXR2i+g80lP7sepQt9oYMg8Yt6aWhcgt6HStgjdAVX8pCfRKdppQ==",
       "dev": true
     },
     "svelte-loading-spinners": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "svelte-checkbox": "^1.0.0-beta.9",
     "svelte-content-loader": "^1.1.3",
     "svelte-headroom": "^2.2.1",
-    "svelte-infinite-scroll": "^1.5.0",
+    "svelte-infinite-scroll": "1.4.0",
     "svelte-loading-spinners": "0.1.1",
     "svelte-preprocess": "^4.5.2",
     "svelte-routing": "^1.4.2",


### PR DESCRIPTION
closes issue #442 

3rd party package used for infinite scrolling broke binding to the window for scrolling and was only bound to the scroll event of the components parent.

Rolled back to 1.4.0 and filed issue at https://github.com/andrelmlins/svelte-infinite-scroll/issues/13