### PR TITLE
bumps svelte-infinite-scroll to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11276,9 +11276,9 @@
       "dev": true
     },
     "svelte-infinite-scroll": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/svelte-infinite-scroll/-/svelte-infinite-scroll-1.4.0.tgz",
-      "integrity": "sha512-Iezoxj24argq/iF6uCW9XN5dM3B7xgSzpUTXR2i+g80lP7sepQt9oYMg8Yt6aWhcgt6HStgjdAVX8pCfRKdppQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/svelte-infinite-scroll/-/svelte-infinite-scroll-1.5.1.tgz",
+      "integrity": "sha512-pg56QCgO6nLD2TkzZvFFsnnmB5wtemHM5iR3kWFKr9EQitsHFm5WO0gcnUOaGbXRj4yEwEuQOiuYVYwsiGbhTA==",
       "dev": true
     },
     "svelte-loading-spinners": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "svelte-checkbox": "^1.0.0-beta.9",
     "svelte-content-loader": "^1.1.3",
     "svelte-headroom": "^2.2.1",
-    "svelte-infinite-scroll": "1.4.0",
+    "svelte-infinite-scroll": "^1.5.1",
     "svelte-loading-spinners": "0.1.1",
     "svelte-preprocess": "^4.5.2",
     "svelte-routing": "^1.4.2",


### PR DESCRIPTION
Bumps https://github.com/andrelmlins/svelte-infinite-scroll/issues/13 to 1.5.1 and verifies window scroll binding is working as expected.