### PR TITLE
Sets better default values for oauth providers

### DIFF
--- a/src/routes/my/Profile.svelte
+++ b/src/routes/my/Profile.svelte
@@ -25,10 +25,10 @@
       isNewProfile = false;
     } else {
       currentProfile = {
-        firstName: $user.given_name,
-        lastName: $user.family_name,
-        profileSlug: $user.nickname,
-        email: $user.email,
+        firstName: $user.given_name ? $user.given_name : '',
+        lastName: $user.family_name ? $user.family_name : '',
+        profileSlug: $user.nickname ? $user.nickname : '',
+        email: $user.email ? $user.email : '',
       };
       isNewProfile = true;
     }


### PR DESCRIPTION
I thought Auth0 was normalizing the values from the different OAuth providers and while it might be we don't always get those values. So if they're not there we now set a more sensible set of defaults. 

closes #297 
closes #453 