### PR TITLE
Removing object.child access when checking for object.

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -78,7 +78,7 @@
     document.getElementById('tidio-chat-iframe').style.zIndex = '2';
 
     unsub = thatProfile.subscribe(currentUser => {
-      if (currentUser.id) {
+      if (currentUser) {
         window.tidioChatApi.setVisitorData({
           distinct_id: currentUser.id,
           email: currentUser.email,

--- a/src/elements/FeaturedActivity-Add.svelte
+++ b/src/elements/FeaturedActivity-Add.svelte
@@ -18,7 +18,7 @@
   >
     <div class="space-y-6 xl:space-y-10">
       <div class="flex justify-center">
-        {#if $isAuthenticated && $thatProfile.canFeature}
+        {#if $isAuthenticated && $thatProfile}
           {#if isHover}
             <Icon
               data="{plusCircle}"
@@ -48,7 +48,7 @@
         <p class="text-thatBlue-200 text-sm italic">Any Day, Any Time</p>
 
         <span class="text-thatBlue-200 text-right">
-          {#if $isAuthenticated && $thatProfile.canFeature}
+          {#if $isAuthenticated && $thatProfile}
             <p>{`${$thatProfile.firstName} ${$thatProfile.lastName}`}</p>
           {:else}
             <p>Your Name Here :)</p>


### PR DESCRIPTION
Really with null coalesce was a thing right now. I was checking for a child object when the parent wasn't there and it was blowing up.

This is what you get when you start tracking those errors ;)

closes #504 