### PR TITLE
Added endOfLine: 'auto' in prettier configs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,6 @@
   "svelteSortOrder": "scripts-markup-styles",
   "svelteStrictMode": true,
   "svelteBracketNewLine": true,
-  "svelteAllowShorthand": true
+  "svelteAllowShorthand": true,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
This fixes an issue with `npm run lint` that lists all prettier errors. 

Previous behavior: Listed thousands of prettier errors and failed.

Fixed behavior: Lists errors correctly and fails. 