### PR TITLE
Grid items' height now consistent in their row

### DIFF
--- a/src/components/communities/CommunityCard.svelte
+++ b/src/components/communities/CommunityCard.svelte
@@ -14,7 +14,7 @@
     </span>
 
     <h3
-      class="mt-4 text-gray-500 font-bold leading-5 text-md font-semibold tracking-tight uppercase"
+      class="mt-4 text-gray-500 font-bold leading-5 text-md tracking-tight uppercase"
     >
       {`${community.name}`}
     </h3>

--- a/src/components/communities/CommunityCard.svelte
+++ b/src/components/communities/CommunityCard.svelte
@@ -3,31 +3,27 @@
   let imageCrop = '?mask=ellipse&w=500&h=500&fit=crop';
 </script>
 
-<div class="bg-white transform hover:scale-110 hover:bg-that-offWhite">
-  <div class="text-center rounded-lg shadow flex-1 flex flex-col p-4">
-    <span class="relative flex ">
-      <img
-        class="mx-auto max-h-32 "
-        src="{community.logo}"
-        alt="{community.name}"
-      />
-    </span>
+<span class="relative flex">
+  <img
+    class="mx-auto max-h-32 "
+    src="{community.logo}"
+    alt="{community.name}"
+  />
+</span>
 
-    <h3
-      class="mt-4 text-gray-500 font-bold leading-5 text-md tracking-tight uppercase"
-    >
-      {`${community.name}`}
-    </h3>
+<h3
+  class="mt-4 text-gray-500 font-bold leading-5 text-md tracking-tight uppercase"
+>
+  {`${community.name}`}
+</h3>
 
-    <div class="mt-2">
-      <p class="text-gray-500 text-sm leading-5">
-        {community.followCount}
-        followers
-      </p>
-      <p class="text-gray-500 text-sm leading-5">
-        {community.sessionCount}
-        activities
-      </p>
-    </div>
-  </div>
+<div class="mt-2">
+  <p class="text-gray-500 text-sm leading-5">
+    {community.followCount}
+    followers
+  </p>
+  <p class="text-gray-500 text-sm leading-5">
+    {community.sessionCount}
+    activities
+  </p>
 </div>

--- a/src/routes/communities/Communities.svelte
+++ b/src/routes/communities/Communities.svelte
@@ -49,10 +49,12 @@
                   lg:grid-cols-5"
               >
                 {#each $state.context.items as c (c.id)}
-                  <li class="col-span-1 flex flex-col">
+                  <li
+                    class="col-span-1 bg-white rounded-lg shadow transform hover:scale-110 hover:bg-that-offWhite"
+                  >
                     <Link
                       href="{`/communities/${c.slug}`}"
-                      class="focus:outline-none"
+                      class="h-full flex flex-col justify-between p-4 text-center focus:outline-none"
                     >
                       <CommunityCard community="{c}" />
                     </Link>


### PR DESCRIPTION
Fixes issue #543. Long titles no longer mess up the cards and their height is now consistent across the grid row. 