### PR TITLE
Issue 531, fixing weird sticky date behavior

### DIFF
--- a/src/components/activities/List.svelte
+++ b/src/components/activities/List.svelte
@@ -175,7 +175,7 @@
     <div in:fade="{{ delay: d * 200 }}">
       <h2
         class="sticky top-0 bg-white text-3xl leading-9 font-extrabold
-        tracking-tight text-thatBlue-800 sm:text-4xl sm:leading-10 pb-12 z-10"
+        tracking-tight text-thatBlue-800 sm:text-4xl sm:leading-10 pb-12 z-10 inline"
       >
         <span> {dayjs(day.dayOfYear).format("dddd MMMM D, 'YY")} </span>
       </h2>
@@ -183,7 +183,7 @@
       {#each day.timeSlots as ts, t}
         <h2
           class="sticky top-12 bg-white text-3xl leading-9 font-extrabold
-            tracking-tight text-thatOrange-400 sm:text-4xl sm:leading-10 z-10"
+            tracking-tight text-thatOrange-400 sm:text-4xl sm:leading-10 z-10 inline"
         >
           {#if !dayjs(ts.timeSlot).isValid()}
             <span>Unscheduled</span>

--- a/src/components/activities/List.svelte
+++ b/src/components/activities/List.svelte
@@ -173,23 +173,23 @@
 
   {#each sorted as day, d}
     <div in:fade="{{ delay: d * 200 }}">
-      <h2
-        class="sticky top-0 z-1 bg-white text-3xl leading-9 font-extrabold
-        tracking-tight text-thatBlue-800 sm:text-4xl sm:leading-10 pt-4 pb-10 inline-block"
+      <span
+        class="sticky top-0 z-20 bg-white text-3xl leading-9 font-extrabold
+        tracking-tight text-thatBlue-800 sm:text-4xl sm:leading-10 pt-4 mb-10"
       >
         <span> {dayjs(day.dayOfYear).format("dddd MMMM D, 'YY")} </span>
-      </h2>
+      </span>
 
       {#each day.timeSlots as ts, t}
-        <div>
-          <h2
-            class="sticky top-14 z-1 bg-white text-3xl leading-9 font-extrabold
-            tracking-tight text-thatOrange-400 sm:text-4xl sm:leading-10 inline-block"
+        <div class="relative">
+          <span
+            class="sticky top-14 z-10 bg-white text-3xl leading-9 font-extrabold
+            tracking-tight text-thatOrange-400 sm:text-4xl sm:leading-10"
           >
             {#if !dayjs(ts.timeSlot).isValid()}
               <span>Unscheduled</span>
             {:else}<span>{dayjs(ts.timeSlot).format('hh:mm a')}</span>{/if}
-          </h2>
+          </span>
 
           <div in:fade="{{ delay: t * 500 }}" class="mb-12">
             <ul

--- a/src/components/activities/List.svelte
+++ b/src/components/activities/List.svelte
@@ -174,23 +174,22 @@
   {#each sorted as day, d}
     <div in:fade="{{ delay: d * 200 }}">
       <h2
-        class="sticky top-2 bg-white text-3xl leading-9 font-extrabold
-        tracking-tight text-thatBlue-800 sm:text-4xl sm:leading-10 pb-2 z-10"
+        class="sticky top-0 bg-white text-3xl leading-9 font-extrabold
+        tracking-tight text-thatBlue-800 sm:text-4xl sm:leading-10 pb-12 z-10"
       >
         <span> {dayjs(day.dayOfYear).format("dddd MMMM D, 'YY")} </span>
       </h2>
 
       {#each day.timeSlots as ts, t}
-        <div in:fade="{{ delay: t * 500 }}" class="pb-12">
-          <h2
-            class="sticky top-12 bg-white text-3xl leading-9 font-extrabold
+        <h2
+          class="sticky top-12 bg-white text-3xl leading-9 font-extrabold
             tracking-tight text-thatOrange-400 sm:text-4xl sm:leading-10 z-10"
-          >
-            {#if !dayjs(ts.timeSlot).isValid()}
-              <span>Unscheduled</span>
-            {:else}<span>{dayjs(ts.timeSlot).format('hh:mm a')}</span>{/if}
-          </h2>
-
+        >
+          {#if !dayjs(ts.timeSlot).isValid()}
+            <span>Unscheduled</span>
+          {:else}<span>{dayjs(ts.timeSlot).format('hh:mm a')}</span>{/if}
+        </h2>
+        <div in:fade="{{ delay: t * 500 }}" class="pb-12">
           <ul class="mt-8 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
             {#each ts.activities as activity (activity.id)}
               {#if isKeynote(activity)}

--- a/src/components/activities/List.svelte
+++ b/src/components/activities/List.svelte
@@ -138,8 +138,8 @@
 </script>
 
 <div class="relative">
-  <div class="sticky z-20 top-4">
-    <div class="absolute top-0 right-0 z-20 border-gray-200">
+  <div class="sticky z-20 top-0">
+    <div class="absolute top-0 right-0 z-20 border-gray-200 pt-4">
       <button
         type="button"
         class="max-w-xs h-10 w-10 rounded-full text-gray-300 focus:outline-none

--- a/src/components/activities/List.svelte
+++ b/src/components/activities/List.svelte
@@ -175,21 +175,21 @@
     <div in:fade="{{ delay: d * 200 }}">
       <h2
         class="sticky top-0 bg-white text-3xl leading-9 font-extrabold
-        tracking-tight text-thatBlue-800 sm:text-4xl sm:leading-10 pb-12 z-10 inline"
+        tracking-tight text-thatBlue-800 sm:text-4xl sm:leading-10 z-10 pb-10"
       >
         <span> {dayjs(day.dayOfYear).format("dddd MMMM D, 'YY")} </span>
       </h2>
 
       {#each day.timeSlots as ts, t}
         <h2
-          class="sticky top-12 bg-white text-3xl leading-9 font-extrabold
-            tracking-tight text-thatOrange-400 sm:text-4xl sm:leading-10 z-10 inline"
+          class="sticky top-10 bg-white text-3xl leading-9 font-extrabold
+            tracking-tight text-thatOrange-400 sm:text-4xl sm:leading-10 z-10"
         >
           {#if !dayjs(ts.timeSlot).isValid()}
             <span>Unscheduled</span>
           {:else}<span>{dayjs(ts.timeSlot).format('hh:mm a')}</span>{/if}
         </h2>
-        <div in:fade="{{ delay: t * 500 }}" class="pb-12">
+        <div in:fade="{{ delay: t * 500 }}" class="mb-12">
           <ul class="mt-8 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
             {#each ts.activities as activity (activity.id)}
               {#if isKeynote(activity)}

--- a/src/components/activities/List.svelte
+++ b/src/components/activities/List.svelte
@@ -176,7 +176,6 @@
       <h2
         class="sticky top-0 z-1 bg-white text-3xl leading-9 font-extrabold
         tracking-tight text-thatBlue-800 sm:text-4xl sm:leading-10 pt-4 pb-10 inline-block"
-        style="z-index: 1"
       >
         <span> {dayjs(day.dayOfYear).format("dddd MMMM D, 'YY")} </span>
       </h2>

--- a/src/components/activities/List.svelte
+++ b/src/components/activities/List.svelte
@@ -174,39 +174,45 @@
   {#each sorted as day, d}
     <div in:fade="{{ delay: d * 200 }}">
       <h2
-        class="sticky top-0 bg-white text-3xl leading-9 font-extrabold
-        tracking-tight text-thatBlue-800 sm:text-4xl sm:leading-10 z-10 pb-10"
+        class="sticky top-0 z-1 bg-white text-3xl leading-9 font-extrabold
+        tracking-tight text-thatBlue-800 sm:text-4xl sm:leading-10 pt-4 pb-10 inline-block"
+        style="z-index: 1"
       >
         <span> {dayjs(day.dayOfYear).format("dddd MMMM D, 'YY")} </span>
       </h2>
 
       {#each day.timeSlots as ts, t}
-        <h2
-          class="sticky top-10 bg-white text-3xl leading-9 font-extrabold
-            tracking-tight text-thatOrange-400 sm:text-4xl sm:leading-10 z-10"
-        >
-          {#if !dayjs(ts.timeSlot).isValid()}
-            <span>Unscheduled</span>
-          {:else}<span>{dayjs(ts.timeSlot).format('hh:mm a')}</span>{/if}
-        </h2>
-        <div in:fade="{{ delay: t * 500 }}" class="mb-12">
-          <ul class="mt-8 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-            {#each ts.activities as activity (activity.id)}
-              {#if isKeynote(activity)}
-                <li
-                  in:fade
-                  class="col-span-1 sm:col-span-2 lg:col-span-3 bg-white
+        <div>
+          <h2
+            class="sticky top-14 z-1 bg-white text-3xl leading-9 font-extrabold
+            tracking-tight text-thatOrange-400 sm:text-4xl sm:leading-10 inline-block"
+          >
+            {#if !dayjs(ts.timeSlot).isValid()}
+              <span>Unscheduled</span>
+            {:else}<span>{dayjs(ts.timeSlot).format('hh:mm a')}</span>{/if}
+          </h2>
+
+          <div in:fade="{{ delay: t * 500 }}" class="mb-12">
+            <ul
+              class="mt-8 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3"
+            >
+              {#each ts.activities as activity (activity.id)}
+                {#if isKeynote(activity)}
+                  <li
+                    in:fade
+                    class="col-span-1 sm:col-span-2 lg:col-span-3 bg-white
                   rounded-lg shadow-lg mt-10 mb-10"
-                >
-                  <KeynoteCard {...activity} />
-                </li>
-              {:else}
-                <li in:fade class="col-span-1 bg-white rounded-lg shadow-lg">
-                  <Card {...activity} editMode="{editMode}" />
-                </li>
-              {/if}
-            {/each}
-          </ul>
+                  >
+                    <KeynoteCard {...activity} />
+                  </li>
+                {:else}
+                  <li in:fade class="col-span-1 bg-white rounded-lg shadow-lg">
+                    <Card {...activity} editMode="{editMode}" />
+                  </li>
+                {/if}
+              {/each}
+            </ul>
+          </div>
         </div>
       {/each}
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -71,6 +71,10 @@ module.exports = {
           900: '#0f213e',
         },
       },
+      // Necessary z-index for the date headers in Activities
+      zIndex: {
+        1: '1',
+      },
     },
   },
   variants: {


### PR DESCRIPTION
Dates in the Activities page now scroll as expected. 

Something needs to be done about the filter when the viewport is of mobile width. See:

![image](https://user-images.githubusercontent.com/58940073/105772691-30fab780-5f28-11eb-8c8d-6aad9fec58aa.png)
