### PR TITLE
Issue 514

### DIFF
--- a/src/components/activities/FilterSlideOver.svelte
+++ b/src/components/activities/FilterSlideOver.svelte
@@ -1,6 +1,7 @@
 <script>
   export let searchterm = '';
   export let tags;
+  export let communities;
   export let selectedTags = [];
 
   import Icon from 'svelte-awesome';
@@ -54,15 +55,37 @@
       <div class="my-2">
         <fieldset class="flex flex-col">
           {#each tags as tag}
+            {#if tag.charAt(0) !== '@'}
+              <label
+                class="capitalize text-base text-gray-500 sm:text-lg sm:mx-auto md:mt-2 md:text-md lg:mx-0"
+              >
+                <input
+                  type="checkbox"
+                  bind:group="{selectedTags}"
+                  value="{tag}"
+                />
+                <span class="px-2">{tag}</span>
+              </label>
+            {/if}
+          {/each}
+        </fieldset>
+      </div>
+
+      <h2 class="mt-4 text-lg leading-7 font-medium text-gray-900">
+        Communities
+      </h2>
+      <div class="mb-2">
+        <fieldset class="flex flex-col">
+          {#each communities as community}
             <label
               class="capitalize text-base text-gray-500 sm:text-lg sm:mx-auto md:mt-2 md:text-md lg:mx-0"
             >
               <input
                 type="checkbox"
                 bind:group="{selectedTags}"
-                value="{tag}"
+                value="@{community}"
               />
-              <span class="px-2">{tag}</span>
+              <span class="px-2">@{community}</span>
             </label>
           {/each}
         </fieldset>

--- a/src/components/activities/FilterSlideOver.svelte
+++ b/src/components/activities/FilterSlideOver.svelte
@@ -2,7 +2,7 @@
   export let searchterm = '';
   export let tags;
   export let communities;
-  export let selectedTags = [];
+  export let selectedFilterTerms = [];
 
   import Icon from 'svelte-awesome';
   import { filter as filterIcon } from 'svelte-awesome/icons';
@@ -45,7 +45,7 @@
           focus:ring-thatBlue-500 focus:border-thatBlue-800 transition
           duration-150 ease-in-out"
           on:click="{() => {
-            selectedTags = [];
+            selectedFilterTerms = [];
           }}"
         >
           Clear selected tags
@@ -61,7 +61,7 @@
               >
                 <input
                   type="checkbox"
-                  bind:group="{selectedTags}"
+                  bind:group="{selectedFilterTerms}"
                   value="{tag}"
                 />
                 <span class="px-2">{tag}</span>
@@ -82,7 +82,7 @@
             >
               <input
                 type="checkbox"
-                bind:group="{selectedTags}"
+                bind:group="{selectedFilterTerms}"
                 value="@{community}"
               />
               <span class="px-2">@{community}</span>

--- a/src/components/activities/FilterSlideOver.svelte
+++ b/src/components/activities/FilterSlideOver.svelte
@@ -40,7 +40,7 @@
           {#each tags as tag}
             {#if tag.charAt(0) !== '@'}
               <label
-                class="capitalize text-base text-gray-500 sm:text-lg sm:mx-auto md:mt-2 md:text-md lg:mx-0 whitespace-nowrap"
+                class="capitalize text-base text-gray-500 sm:text-lg md:mt-2 md:text-md lg:mx-0 whitespace-nowrap"
               >
                 <input
                   type="checkbox"
@@ -58,7 +58,7 @@
         <fieldset class="flex flex-col">
           {#each communities as community}
             <label
-              class="capitalize text-base text-gray-500 sm:text-lg sm:mx-auto md:mt-2 md:text-md lg:mx-0 whitespace-nowrap"
+              class="capitalize text-base text-gray-500 sm:text-lg md:mt-2 md:text-md lg:mx-0 whitespace-nowrap"
             >
               <input
                 type="checkbox"
@@ -70,6 +70,24 @@
           {/each}
         </fieldset>
       </div>
+
+      {#if selectedFilterTerms.length}
+        <div class="absolute bottom-0 left-0 w-full flex justify-center">
+          <button
+            type="button"
+            class="inline-block w-full md:w-auto mx-4 md:mx-0 my-2 px-4 py-2 rounded-md shadow text-base font-medium border-2
+          border-thatBlue-500 text-thatBlue-500 bg-white hover:bg-thatBlue-500
+          hover:text-white focus:bg-thatBlue-500 focus:text-white focus:outline-none
+          focus:ring-thatBlue-500 focus:border-thatBlue-800 transition
+          duration-150 ease-in-out"
+            on:click="{() => {
+              selectedFilterTerms = [];
+            }}"
+          >
+            {`Clear ${selectedFilterTerms.length} selected tag${selectedFilterTerms.length > 1 ? 's' : ''}`}
+          </button>
+        </div>
+      {/if}
     </div>
   </div>
 </SlideOver>

--- a/src/components/activities/FilterSlideOver.svelte
+++ b/src/components/activities/FilterSlideOver.svelte
@@ -33,31 +33,14 @@
       </div>
     </div>
 
-    <div class="py-12">
-      <div class="flex items-center justify-between">
+    <div class="py-12 flex justify-between">
+      <div class="mr-3">
         <h2 class="text-lg leading-7 font-medium text-gray-900">Tags</h2>
-
-        <button
-          type="button"
-          class="inline-block my-2 px-4 py-2 rounded-md shadow text-base font-medium border-2
-          border-thatBlue-500 text-thatBlue-500 bg-white hover:bg-thatBlue-500
-          hover:text-white focus:bg-thatBlue-500 focus:text-white focus:outline-none
-          focus:ring-thatBlue-500 focus:border-thatBlue-800 transition
-          duration-150 ease-in-out"
-          on:click="{() => {
-            selectedFilterTerms = [];
-          }}"
-        >
-          Clear selected tags
-        </button>
-      </div>
-
-      <div class="my-2">
         <fieldset class="flex flex-col">
           {#each tags as tag}
             {#if tag.charAt(0) !== '@'}
               <label
-                class="capitalize text-base text-gray-500 sm:text-lg sm:mx-auto md:mt-2 md:text-md lg:mx-0"
+                class="capitalize text-base text-gray-500 sm:text-lg sm:mx-auto md:mt-2 md:text-md lg:mx-0 whitespace-nowrap"
               >
                 <input
                   type="checkbox"
@@ -70,15 +53,12 @@
           {/each}
         </fieldset>
       </div>
-
-      <h2 class="mt-4 text-lg leading-7 font-medium text-gray-900">
-        Communities
-      </h2>
-      <div class="mb-2">
+      <div class="ml-3">
+        <h2 class="text-lg leading-7 font-medium text-gray-900">Communities</h2>
         <fieldset class="flex flex-col">
           {#each communities as community}
             <label
-              class="capitalize text-base text-gray-500 sm:text-lg sm:mx-auto md:mt-2 md:text-md lg:mx-0"
+              class="capitalize text-base text-gray-500 sm:text-lg sm:mx-auto md:mt-2 md:text-md lg:mx-0 whitespace-nowrap"
             >
               <input
                 type="checkbox"

--- a/src/components/activities/List.svelte
+++ b/src/components/activities/List.svelte
@@ -45,15 +45,21 @@
   let fuse;
   let filterVisible;
   let tags = [];
+  let communities = [];
   let selectedTags = getSessionSelectedTags();
   let activitiesTaggedFiltered = [];
 
   $: {
     const tagsSet = new Set();
+    const communitiesSet = new Set();
 
     for (const activity of activities) {
       for (const tag of activity.tags) {
         tagsSet.add(tag.toLowerCase());
+      }
+
+      for (const community of activity.communities) {
+        communitiesSet.add(community.toLowerCase());
       }
     }
 
@@ -66,6 +72,8 @@
       }
       return 0;
     });
+
+    communities = Array.from(communitiesSet.values());
   }
 
   $: window.sessionStorage.setItem(
@@ -164,6 +172,7 @@
   {#if filterVisible}
     <FilterSlideOver
       tags="{tags}"
+      communities="{communities}"
       bind:selectedTags
       bind:searchterm
       on:click="{handleCloseFilter}"

--- a/src/components/activities/List.svelte
+++ b/src/components/activities/List.svelte
@@ -47,7 +47,7 @@
   let filterVisible;
   let tags = [];
   let communities = [];
-  let selectedTags = getSessionSelectedTags();
+  let selectedFilterTerms = getSessionSelectedTags();
   let activitiesTaggedFiltered = [];
 
   $: {
@@ -79,13 +79,13 @@
 
   $: window.sessionStorage.setItem(
     'selectedTags',
-    JSON.stringify(selectedTags),
+    JSON.stringify(selectedFilterTerms),
   );
 
   $: activitiesTaggedFiltered =
-    selectedTags.length > 0
+    selectedFilterTerms.length > 0
       ? activitiesFiltered.filter(activity =>
-          selectedTags.some(tag =>
+          selectedFilterTerms.some(tag =>
             activity.tags.some(t => t.toLowerCase() === tag),
           ),
         )
@@ -154,8 +154,8 @@
         class="max-w-xs h-10 w-10 rounded-full text-gray-300 focus:outline-none
           duration-150 ease-in-out hover:bg-thatBlue-500"
         class:bg-thatBlue-500="{filterVisible}"
-        class:bg-thatRed-500="{selectedTags.length > 0}"
-        aria-label="{`Show filter and tags options${selectedTags.length > 0 ? ` (Selected tags: ${selectedTags.join(', ')})` : ''}`}"
+        class:bg-thatRed-500="{selectedFilterTerms.length > 0}"
+        aria-label="{`Show filter and tags options${selectedFilterTerms.length > 0 ? ` (Selected tags: ${selectedFilterTerms.join(', ')})` : ''}`}"
         on:click="{() => {
           filterVisible = true;
         }}"
@@ -174,7 +174,7 @@
     <FilterSlideOver
       tags="{tags}"
       communities="{communities}"
-      bind:selectedTags
+      bind:selectedFilterTerms
       bind:searchterm
       on:click="{handleCloseFilter}"
       on:clicked-outside="{handleCloseFilter}"

--- a/src/components/activities/List.svelte
+++ b/src/components/activities/List.svelte
@@ -35,6 +35,7 @@
       'title',
       'shortDescription',
       'tags',
+      'communities',
       'speakers.firstName',
       'speakers.lastName',
     ],

--- a/src/dataSources/api.that.tech/sessions.js
+++ b/src/dataSources/api.that.tech/sessions.js
@@ -15,6 +15,7 @@ const coreSessionFields = `
     startTime
     durationInMinutes
     slug
+    communities
   }
 `;
 

--- a/src/elements/overlays/BasicSlideOver.svelte
+++ b/src/elements/overlays/BasicSlideOver.svelte
@@ -7,16 +7,18 @@
 
 <div
   class="z-30 fixed inset-0 overflow-hidden"
-  on:click|stopPropagation={() => { dispatch('clicked-outside', 'clicked'); }}
+  on:click|stopPropagation="{() => {
+    dispatch('clicked-outside', 'clicked');
+  }}"
 >
   <div class="absolute inset-0 overflow-hidden">
     <section
       in:fly="{{ x: 400, duration: 1000 }}"
       out:fly="{{ x: 400, duration: 1000 }}"
-      class="z-30 absolute inset-y-0 right-0 pl-10 max-w-full flex"
-      on:click|stopPropagation={() => {}}
+      class="z-30 absolute inset-y-0 right-0 max-w-full flex"
+      on:click|stopPropagation="{() => {}}"
     >
-      <div class="w-screen max-w-md border-l-4 border-thatOrange-400">
+      <div class="w-screen md:w-auto border-l-4 border-thatOrange-400">
         <div class="h-full divide-y divide-gray-200 flex flex-col bg-white ">
           <div
             class="min-h-0 flex-1 flex flex-col py-6 space-y-6 overflow-y-scroll"

--- a/src/elements/overlays/BasicSlideOver.svelte
+++ b/src/elements/overlays/BasicSlideOver.svelte
@@ -51,7 +51,7 @@
               </div>
             </header>
 
-            <div class="relative flex-1 px-4 sm:px-6">
+            <div class="flex-1 px-4 sm:px-6">
               <div class="h-full">
                 <slot />
               </div>


### PR DESCRIPTION
Communities now appear as a separate list in the filter slide-over. They've been queried along with the rest of the Activities data and formatted into a separate array, which is passed as a prop to `FilterSlideOver`. However, to avoid reinventing the wheel, they've been simply prefixed with an `@` symbol and will get passed as a tag if it's selected. This, IMO, removes the necessity to filter the list in respective to two different arrays, since the tag data (which is identical to the community data) already exists.