### PR TITLE
Addresses issue 573

### DIFF
--- a/src/dataSources/api.that.tech/favorites.js
+++ b/src/dataSources/api.that.tech/favorites.js
@@ -10,6 +10,7 @@ const favoriteFragment = `
     status
     startTime
     tags
+    communities
     speakers {
       id
       firstName

--- a/src/dataSources/api.that.tech/submissions.js
+++ b/src/dataSources/api.that.tech/submissions.js
@@ -15,6 +15,7 @@ export const QUERY_SUBMISSIONS = `
             status
             startTime
             tags
+            communities
             durationInMinutes
             speakers {
               id


### PR DESCRIPTION
**Problem addressed**: 

Issue #573. Activities feed crashed due to the missing communities fragment, a bug mistakenly introduced by yours truly. 

**Problem fixed**: 

Added `communities` to `favoriteFragment`. Seems to be working now. 
