### PR TITLE
now queries for all favorites across all events

### DIFF
--- a/src/dataSources/api.that.tech/favorites.js
+++ b/src/dataSources/api.that.tech/favorites.js
@@ -58,7 +58,7 @@ export default client => {
 
   function query(eventId) {
     const variables = {
-      eventId,
+      eventId: 'ANY',
     };
 
     return client


### PR DESCRIPTION
We will want to re-address this later but for now, favorites is queried across all events and returns all. 

We will want a better long-term strategy.