### PR TITLE
fixes null session references

### DIFF
--- a/src/routes/home/machines/upNext.js
+++ b/src/routes/home/machines/upNext.js
@@ -31,12 +31,12 @@ function createServices(client) {
         }),
 
       loadSuccess: assign({
-        items: (_, { data }) => data.sessions,
+        items: (_, { data }) => data.sessions.filter(s => s),
         cursor: (_, { data }) => data.cursor,
       }),
 
       loadNextSuccess: assign({
-        items: (context, { data }) => data.sessions,
+        items: (context, { data }) => data.sessions.filter(s => s),
         cursor: (_, { data }) => data.cursor,
       }),
 


### PR DESCRIPTION
When Christopher flipped his profile private his accepted activities were coming back as nulls and killing the component.