### PR TITLE
fixes #720

### DIFF
--- a/src/routes/activities/lib/formatRequest.js
+++ b/src/routes/activities/lib/formatRequest.js
@@ -40,7 +40,6 @@ function cleanValuesForUpdate(values) {
   delete newValues.selectedTime;
   delete newValues.selectedTimezone;
   delete newValues.selectedDuration;
-  delete newValues.eventId;
 
   return newValues;
 }


### PR DESCRIPTION
Formatter was deleting eventId on update, causing the event to never change.

closes #720 