### PR TITLE
Date wasn't being populated on edit

### DIFF
--- a/src/dataSources/api.that.tech/sessions/queries.js
+++ b/src/dataSources/api.that.tech/sessions/queries.js
@@ -60,6 +60,11 @@ const onBaseFields = `
   fragment onBaseFields on Base {
     id
     eventId
+    event {
+      id
+      startDate
+      endDate
+    }
     slug
     title
     shortDescription

--- a/src/routes/activities/components/form/initialValues.js
+++ b/src/routes/activities/components/form/initialValues.js
@@ -30,7 +30,7 @@ export function formatActivityInitialInput(currentData) {
   const results = {
     ...currentData,
     event: {
-      id: eventId || id,
+      id,
       startDate,
       endDate,
     },


### PR DESCRIPTION
Now query the event start/end date from the session which is how it was before we went to the union based session results. Now things are populating in the correct order and the datepicker is happy.