### PR TITLE
now passes order reference too

### DIFF
--- a/src/dataSources/api.that.tech/orders/mutations.js
+++ b/src/dataSources/api.that.tech/orders/mutations.js
@@ -15,10 +15,10 @@ export const MUTATION_CREATE_CHECKOUT_SESSION = `
 `;
 
 export const MUTATION_MARK_SURVEY_QUESTIONS_COMPLETED = `
-  mutation createCheckoutSession($eventId: ID!) {
+  mutation createCheckoutSession($eventId: ID!, $orderReference: String) {
     orders {
       me {
-        markQuestionsComplete(eventId: $eventId)
+        markQuestionsComplete(eventId: $eventId, orderReference: $orderReference)
       }
     }
   }
@@ -77,9 +77,10 @@ export default client => {
       });
   }
 
-  function markSurveyQuestionsCompleted(eventId) {
+  function markSurveyQuestionsCompleted(eventId, orderReference) {
     const variables = {
       eventId,
+      orderReference,
     };
 
     return client

--- a/src/routes/orders/ThatSuccess.svelte
+++ b/src/routes/orders/ThatSuccess.svelte
@@ -17,7 +17,7 @@
 
   const apiClient = getClient();
   const { send } = getContext('cart');
-  const { eventId } = qs.parse(location.search);
+  const { eventId, orderReference } = qs.parse(location.search);
 
   $: questionsCompleted = false;
   let formDataPrefill;
@@ -42,7 +42,7 @@
 
   function handleOnSubmit(e) {
     return ordersApi(apiClient)
-      .markSurveyQuestionsCompleted(eventId)
+      .markSurveyQuestionsCompleted(eventId, orderReference)
       .then(results => {
         questionsCompleted = results;
       });


### PR DESCRIPTION
Updates api call to also now pass along order reference.

[] not sure if that's the right key to pull off the queryString