### PR TITLE
Added Tailwind JIT Mode and modified the rollup watch config.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -95,5 +95,6 @@ export default {
   ],
   watch: {
     clearScreen: false,
+    buildDelay: 2000,
   },
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@
 const colors = require('tailwindcss/colors');
 
 module.exports = {
+  mode: 'jit',
   theme: {
     interFontFeatures: {
       default: ['calt', 'liga', 'kern'],


### PR DESCRIPTION
Added the mode: 'jit' to the tailwind config, which successfully generates the css styles on demand. You can test this by running `npm run dev`, navigating to localhost:5000 and then changing the text color of **Geeks** in 'src/components/home/Hero.svelte line:18' from _text-thatOrange-400_ to _text-[#ceff00]_. You will see rollup rebuild files, and the change will be live in your web browser.

**ISSUE: ** - I'm leaving this PR as a draft because when implementing this change, I had to add `buildDelay: 2000` to the watch object in rollup.config.js. If you remove this, you will notice that the project will rebuild, the changes will be applied, and then it will rebuild again. I haven't been able to track down the cause of the second rebuild, but adding the short build delay does appear to resolve the issue. Would like another opinion on this before publishing.