### PR TITLE
Added concept for Camp Counselor sessions. Also fixed "phantom" shadow on sticky scroll.

### DIFF
--- a/public/images/Trees-Solid-White.svg
+++ b/public/images/Trees-Solid-White.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 1920 1080" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g transform="matrix(1.25175,0,0,1.25175,960.169,539.85)">
+        <g transform="matrix(1,0,0,1,-750,-392)">
+            <path d="M1124.24,442.64L1012.06,263.92L1053.48,263.92L934.64,75.26L815.8,263.92L857.21,263.92L750,434.74L642.79,263.92L684.2,263.92L565.36,75.26L446.52,263.92L487.94,263.92L375.76,442.64L417.13,442.64L300.34,629.64L517.19,629.64L517.19,708.77L613.53,708.77L613.53,629.61L886.47,629.61L886.47,708.74L982.81,708.74L982.81,629.61L1199.66,629.61L1082.87,442.61L1124.24,442.64ZM713.6,442.64L786.41,442.64L750,500.92L713.6,442.64Z" style="fill:rgb(255,255,255);fill-rule:nonzero;"/>
+            <path d="M211.64,142.25L25,328.89L76.85,380.74L211.64,515.54L263.49,463.69L128.69,328.89L263.49,194.1L211.64,142.25Z" style="fill:rgb(255,255,255);fill-rule:nonzero;"/>
+            <path d="M1423.15,277.05L1288.36,142.25L1236.51,194.1L1371.31,328.89L1236.51,463.69L1288.36,515.54L1423.15,380.74L1475,328.89L1423.15,277.05Z" style="fill:rgb(255,255,255);fill-rule:nonzero;"/>
+        </g>
+    </g>
+</svg>

--- a/src/components/activities/ActivityDetails.svelte
+++ b/src/components/activities/ActivityDetails.svelte
@@ -185,21 +185,21 @@
   <!--header-->
   <div class="px-4 py-5 border-b border-gray-300 sm:px-6">
     <div
-      class="-ml-4 -mt-4 flex justify-between items-center flex-wrap
+      class="flex justify-between md:items-end items-center flex-wrap
         sm:flex-nowrap flex-col md:flex-row">
-      <div class="ml-4 mt-4">
-        <div class="flex items-center">
+      <div class="">
+        <div class="flex md:flex-row flex-col items-center md:items-end">
           <div class="flex-shrink-0">
             <Link href="/members/{host.profileSlug}" open>
               <span class="inline-block relative">
                 <img
-                  class="h-12 w-12 rounded-full"
+                  class="h-24 w-24 rounded-full"
                   src="{userProfileImage}"
                   alt=""
                   loading="lazy" />
 
                 {#if host.earnedMeritBadges.length > 0}
-                  <span class="absolute bottom-0 left-0 block h-5 w-5">
+                  <span class="absolute bottom-0 left-0 block h-8 w-8">
                     <img
                       src="{host.earnedMeritBadges[0].image}"
                       alt="{host.earnedMeritBadges[0].name}"
@@ -209,21 +209,36 @@
               </span>
             </Link>
           </div>
-          <div class="ml-4">
-            <h3 class="text-lg leading-6 font-medium text-gray-900">
-              {`${host.firstName} ${host.lastName}`}
-            </h3>
-
-            <div>
-              {#each host.profileLinks as link}
-                <SocialLink href="{link.url}" network="{link.linkType}" />
+          <div class="md:ml-4">
+            <div class="flex flex-col md:items-start items-center">
+              <h3
+                class="text-lg leading-6 font-medium text-gray-900 inline-block">
+                {`${host.firstName} ${host.lastName}`}
+              </h3>
+              {#if type === 'REGULAR' || type === 'WORKSHOP'}
+                <span class="flex flex-row items-center overflow-clip">
+                  <img
+                    src="/images/Trees-Solid.svg"
+                    class="h-5 inline mr-2"
+                    alt="THAT Trees" />
+                  <span class="text-that-red text-lg font-medium inline"
+                    >Counselor</span>
+                </span>
+              {/if}
+            </div>
+            <div class="md:text-left text-center">
+              {#each host.profileLinks as link, i}
+                <SocialLink
+                  href="{link.url}"
+                  network="{link.linkType}"
+                  isLast="{i === host.profileLinks?.length - 1}" />
               {/each}
             </div>
           </div>
         </div>
       </div>
 
-      <div class="pt-4 -m-2 flex flex-wrap justify-center items-center">
+      <div class="flex flex-wrap justify-center items-center mt-2 md:mt-0">
         {#if !hasExpired}
           {#if $isAuthenticated && !incompleteProfile}
             <div class="mt-2 mx-2 rounded-md shadow-sm">

--- a/src/components/activities/ActivityDetails.svelte
+++ b/src/components/activities/ActivityDetails.svelte
@@ -215,14 +215,10 @@
                 class="text-lg leading-6 font-medium text-gray-900 inline-block">
                 {`${host.firstName} ${host.lastName}`}
               </h3>
-              {#if type === 'REGULAR' || type === 'WORKSHOP'}
+              {#if type !== 'OPEN_SPACE' && host.profileSlug != 'thatconference'}
                 <span class="flex flex-row items-center overflow-clip">
-                  <img
-                    src="/images/Trees-Solid.svg"
-                    class="h-5 inline mr-2"
-                    alt="THAT Trees" />
                   <span class="text-that-red text-lg font-medium inline"
-                    >Counselor</span>
+                    >Camp Counselor</span>
                 </span>
               {/if}
             </div>

--- a/src/components/activities/Card.svelte
+++ b/src/components/activities/Card.svelte
@@ -2,6 +2,7 @@
   export let editMode = false;
   export let id;
   export let title;
+  export let type;
   export let shortDescription;
   export let startTime;
   export let durationInMinutes;
@@ -137,19 +138,34 @@
 </script>
 
 <div
-  class="w-full h-full flex flex-col"
-  class:requiresAccess="{requiresAccessToJoin}">
-  <div class="flex items-center p-3 space-x-3">
+  class="{`w-full h-full flex flex-col ${
+    requiresAccessToJoin ? 'rounded-lg border-t-4 border-red-500' : ''
+  }`}">
+  {#if type === 'REGULAR' || type === 'WORKSHOP'}
+    <div class="relative w-full text-center">
+      <div
+        class="inline-block absolute top-8 right-0 bg-that-red rounded-l-lg p-2 shadow-sm">
+        <div class="flex flex-col">
+          <img
+            src="/images/Trees-Solid-White.svg"
+            class="h-5"
+            alt="THAT Trees" />
+          <span class="text-white uppercase text-xs">Certified</span>
+        </div>
+      </div>
+    </div>
+  {/if}
+  <div class="flex flex-col items-center p-3 w-full">
     <Link open href="/members/{host.profileSlug}" class="flex-shrink-0">
       <span class="inline-block relative">
         <img
-          class="w-15 h-15 rounded-full"
+          class="w-24 h-24 rounded-full"
           src="{userProfileImage}"
           alt="{`${host.firstName} ${host.lastName}`}"
           loading="lazy" />
 
         {#if host.earnedMeritBadges.length > 0}
-          <span class="absolute bottom-0 left-0 block h-6 w-6">
+          <span class="absolute bottom-0 left-0 block h-8 w-8">
             <img
               src="{host.earnedMeritBadges[0].image}"
               alt="{host.earnedMeritBadges[0].name}"
@@ -158,18 +174,20 @@
         {/if}
       </span>
     </Link>
-    <div class="flex flex-col">
-      <h3 class="text-gray-900 text-sm leading-5 font-medium break-words">
+
+    <div class="flex flex-col text-center justify-center w-full">
+      <h3
+        class="text-gray-900 text-base leading-5 font-medium break-words pt-1">
         {title}
       </h3>
-      <h3 class="text-gray-400 text-sm leading-5 pt-2">
+      <h3 class="text-gray-400 text-sm leading-5 pt-1">
         {`${host.firstName} ${host.lastName}`}
       </h3>
     </div>
   </div>
 
   <div
-    class="flex-grow p-3"
+    class="flex-grow px-3 pb-3"
     class:cursor-pointer="{isLongerThan(shortDescription, 25)}"
     on:click|preventDefault="{() => (expandDescription = !expandDescription)}">
     <p class="text-gray-500 text-sm leading-5 break-words">
@@ -186,7 +204,7 @@
     </p>
   </div>
 
-  <div class="flex flex-wrap items-center justify-center space-x-4 px-4 pb-5">
+  <div class="flex flex-wrap items-center justify-center space-x-4 px-4 pb-3">
     {#each tags as t}
       <Tag>{t}</Tag>
     {/each}
@@ -289,9 +307,3 @@
     </div>
   {/if}
 </div>
-
-<style>
-  .requiresAccess {
-    @apply rounded-lg border-t-4 border-red-500;
-  }
-</style>

--- a/src/components/activities/Card.svelte
+++ b/src/components/activities/Card.svelte
@@ -141,15 +141,12 @@
   class="{`w-full h-full flex flex-col ${
     requiresAccessToJoin ? 'rounded-lg border-t-4 border-red-500' : ''
   }`}">
-  {#if type === 'REGULAR' || type === 'WORKSHOP'}
+  {#if type !== 'OPEN_SPACE' && host.profileSlug != 'thatconference'}
     <div class="relative w-full text-center">
       <div
-        class="inline-block absolute top-8 right-0 bg-that-red rounded-l-lg p-2 shadow-sm">
-        <div class="flex flex-col">
-          <img
-            src="/images/Trees-Solid-White.svg"
-            class="h-5"
-            alt="THAT Trees" />
+        class="inline-block absolute top-8 right-0 bg-that-red rounded-l-xl p-2 pl-3 shadow-sm">
+        <div class="flex flex-col items-center">
+          <span class="text-white uppercase text-xs">Camp</span>
           <span class="text-white uppercase text-xs">Counselor</span>
         </div>
       </div>

--- a/src/components/activities/Card.svelte
+++ b/src/components/activities/Card.svelte
@@ -150,7 +150,7 @@
             src="/images/Trees-Solid-White.svg"
             class="h-5"
             alt="THAT Trees" />
-          <span class="text-white uppercase text-xs">Certified</span>
+          <span class="text-white uppercase text-xs">Counselor</span>
         </div>
       </div>
     </div>

--- a/src/components/activities/List.svelte
+++ b/src/components/activities/List.svelte
@@ -184,14 +184,18 @@
     {#each sorted as day, d}
       <div>
         <h2
-          class="sticky top-0 z-20 bg-gray-100 text-xl md:text-4xl leading-9 font-extrabold tracking-tight text-thatBlue-800 sm:leading-10 pt-4 mb-7 sm:mb-9 whitespace-nowrap">
+          class="sticky top-0 z-20 bg-gray-100 text-xl md:text-4xl leading-9 
+                 font-extrabold tracking-tight text-thatBlue-800 sm:leading-10 
+                 pt-4 mb-7 sm:mb-9 whitespace-nowrap -ml-5 sm:-ml-6 pl-5 sm:pl-6 -mr-5 sm:-mr-6">
           {dayjs(day.dayOfYear).format("dddd, MMMM D, 'YY")}
         </h2>
 
         {#each day.timeSlots as ts, t}
           <div class="relative">
             <h2
-              class="sticky top-11 sm:top-13 z-10 bg-gray-100 text-xl md:text-4xl leading-9 font-extrabold tracking-tight text-thatOrange-400 sm:leading-10 whitespace-nowrap">
+              class="sticky top-11 sm:top-13 z-10 bg-gray-100 text-xl md:text-4xl 
+                     leading-9 font-extrabold tracking-tight text-thatOrange-400 
+                     sm:leading-10 whitespace-nowrap -ml-5 sm:-ml-6 pl-5 sm:pl-6 -mr-5 sm:-mr-6">
               {#if !dayjs(ts.timeSlot).isValid()}
                 Unscheduled
               {:else}{dayjs(ts.timeSlot).format('hh:mm a')}{/if}

--- a/src/components/social/SocialLink.svelte
+++ b/src/components/social/SocialLink.svelte
@@ -16,6 +16,7 @@
 
   export let network;
   export let href;
+  export let isLast = false;
 
   let socialIcon;
 
@@ -59,5 +60,7 @@
 <a href="{href}" target="_blank" tabindex="-1" rel="noopener">
   <Icon
     data="{socialIcon}"
-    class="transition duration-500 ease-in-out transform hover:scale-125 cursor-pointer mr-2 h-5 w-5 text-gray-400 hover:text-that-blue focus:underline" />
+    class="{`transition duration-500 ease-in-out transform hover:scale-125 cursor-pointer ${
+      !isLast ? 'mr-2' : ''
+    } h-5 w-5 text-gray-400 hover:text-that-blue focus:underline`}" />
 </a>


### PR DESCRIPTION
Added a concept for "THAT Certified" sessions. This does take up slightly more vertical space, but also better highlights the speaker of each of the sessions IMO. With the talk of adding a "cozy" layout to this as well, this is probably okay.

## Before Change 
![image](https://user-images.githubusercontent.com/8643537/123554767-3e220980-d747-11eb-99b2-193976eadf73.png)

## After Change
![image](https://user-images.githubusercontent.com/8643537/123554787-58f47e00-d747-11eb-8134-536c381aaa36.png)

Also can always change the verbiage, not sure what your thoughts were here @csell5.


Snuck in a bit of code for a design thing that was bothering me in the sticky timeslot headers on the activity list.

## Before Change (Notice Shadows Outside Sticky Header)
![image](https://user-images.githubusercontent.com/8643537/123554715-e84d6180-d746-11eb-80c9-30460af7eae1.png)

## After Change
![image](https://user-images.githubusercontent.com/8643537/123554742-18950000-d747-11eb-9c2b-03c7a488cfe3.png)
