### PR TITLE
Activity Form Hybrid Selection startDate endDate

### DIFF
--- a/src/routes/activities/components/form/ActivityForm.svelte
+++ b/src/routes/activities/components/form/ActivityForm.svelte
@@ -58,7 +58,7 @@
   }
 
   function handleEventSelected({ detail }) {
-    const { type } = detail;
+    const { type, startDate, endDate } = detail;
 
     switch (type) {
       case 'DAILY':
@@ -76,8 +76,8 @@
         if (!isBackdoor && !isEdit) {
           if (
             dayjs().isBetween(
-              dayjs(eventSelected.startDate).subtract(2, 'week'),
-              dayjs(eventSelected.endDate),
+              dayjs(startDate).subtract(2, 'week'),
+              dayjs(endDate),
               'day',
             )
           ) {


### PR DESCRIPTION
the activity form wasn't showing the correct long/short form. the eventSelected wasn't getting the correct start/end date. Now it pulls it off the event data vs the global var.