### PR TITLE
reworks the cancel/withdraw on activity edit

### DIFF
--- a/src/routes/activities/_components/form/ActivityForm.svelte
+++ b/src/routes/activities/_components/form/ActivityForm.svelte
@@ -345,7 +345,7 @@
 								<span class="inline-flex rounded-md shadow-sm">
 									<button
 										disabled={isValid}
-										on:click|preventDefault={handleWithdraw}
+										on:click|preventDefault={() => handleWithdraw(initialData)}
 										tabindex="-1"
 										class="w-full py-2 px-4 order 
                           border-2 border-transparent rounded-md

--- a/src/routes/activities/edit/[activityId].svelte
+++ b/src/routes/activities/edit/[activityId].svelte
@@ -53,19 +53,20 @@
 		return queryMySessionById(activityId);
 	}
 
-	async function handleWithdraw() {
-		const status = activityDetails.type === 'OPEN_SPACE' ? 'CANCELLED' : 'WITHDREW';
+	async function handleWithdraw(activity) {
+		const status = activity.type === 'OPEN_SPACE' ? 'CANCELLED' : 'WITHDREW';
 
-		await updateSession(activityId, activityDetails.type, {
+		await updateSession(activity.id, activity.type, {
 			status
 		});
 
 		logEvent('activity_withdraw');
 
-		goto(`/my/submissions`, { replace: true });
+		goto(`/my/submissions`);
 	}
 
 	async function handleSubmit({ detail: { values, setSubmitting, resetForm } }) {
+		setSubmitting(true);
 		const { activity, type } = formatUpdate(values);
 
 		await updateSession(activityId, type, activity);


### PR DESCRIPTION
We now pass the activity details with the event and take the data from that.

fixes #895 