### PR TITLE
show search on mobile checkin

### DIFF
--- a/src/routes/event/check-in/_components/_OrderView.svelte
+++ b/src/routes/event/check-in/_components/_OrderView.svelte
@@ -47,10 +47,10 @@
 
 <section>
 	<div>
-		<div class="flex space-x-8 items-center">
+		<div class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-8 sm:items-center">
 			<input
 				autofocus
-				class="form-input border rounded-md hidden sm:inline"
+				class="form-input border rounded-md"
 				bind:value={searchterm}
 				placeholder="type to search..."
 			/>

--- a/src/routes/event/check-in/_components/_TicketView.svelte
+++ b/src/routes/event/check-in/_components/_TicketView.svelte
@@ -114,10 +114,10 @@
 </script>
 
 <section>
-	<div class="flex space-x-8 items-center">
+	<div class="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-8 sm:items-center">
 		<input
 			autofocus
-			class="form-input border rounded-md hidden sm:inline"
+			class="form-input border rounded-md"
 			bind:value={searchterm}
 			placeholder="type to search..."
 		/>


### PR DESCRIPTION
fixes #856 

Search on checkin pages on a mobile device were hidden.

Changed searc and toggles to be flec-col on mobile with increased Y spacing, and reset to row starting at sm.

Images are iPhone SE and iPhone 12 Pro Max (Simulators)
![Screen Shot 2021-10-18 at 8 56 38 PM](https://user-images.githubusercontent.com/1631560/137826711-b677f1d0-7ee1-4f29-8b47-2ee6df66b0c3.png)
![Screen Shot 2021-10-18 at 8 55 50 PM](https://user-images.githubusercontent.com/1631560/137826715-30d327ae-5951-4492-b9df-a019c56ef14a.png)


