### PR TITLE
fix staying-up-to-date direct navigation fails

### DIFF
--- a/src/routes/support/staying-up-to-date.svelte
+++ b/src/routes/support/staying-up-to-date.svelte
@@ -33,7 +33,7 @@
 	});
 
 	onDestroy(() => {
-		clipboard.destroy();
+		if (clipboard) clipboard.destroy();
 	});
 </script>
 


### PR DESCRIPTION
fixes #994

In looking at this, when navigated to directly, when onDestroy was called clipboard was undefined thus causing the 500 error. 

I added an if check to verify clipboard was instantiated.

The copy calendar url in both scenarios (navigated to, direct access) still works.