### PR TITLE
1085 - Update the z-index of the footer so the tree SVG is behind the…

### DIFF
--- a/src/_components/footer/Footer.svelte
+++ b/src/_components/footer/Footer.svelte
@@ -5,10 +5,9 @@
 	import socials from './socials';
 
 	import { thatLinks, supportLinks, companyLinks, legalLinks } from './links';
-
 </script>
 
-<footer class="bg-white border-t border-gray-200" aria-labelledby="footerHeading">
+<footer class="bg-white border-t border-gray-200 z-10" aria-labelledby="footerHeading">
 	<h2 id="footerHeading" class="sr-only">Footer</h2>
 	<div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:py-16 lg:px-8">
 		<div class="xl:grid xl:grid-cols-3 xl:gap-8">


### PR DESCRIPTION
… footer links when the viewport size is changed.

#1085 

Update to the z-index on the footer, so the trees do not overlap the footer links when the viewport is resized.

![image](https://user-images.githubusercontent.com/17070695/146118889-dc92e229-1d97-4f1b-b2a8-85f7c171791a.png)
