### PR TITLE
868 Update hybrid event hero h1 div z-index

### DIFF
--- a/src/routes/events/_components/hybrid/_Hero.svelte
+++ b/src/routes/events/_components/hybrid/_Hero.svelte
@@ -11,7 +11,7 @@
 <div class="relative bg-thatBlue-200 bg-opacity-25">
 	<div class="mx-auto max-w-7xl w-full pt-10 pb-10 text-center">
 		<div class="flex flex-col">
-			<div class="z-10 transform translate-y-40">
+			<div class="z-[1] transform translate-y-40">
 				<h1
 					class="animate__animated animate__pulse shadowText relative font-extrabold uppercase text-thatBlue-500 text-4xl sm:text-5xl md:text-6xl lg:text-5xl xl:text-6xl"
 				>


### PR DESCRIPTION
Decreased the z-index of the div wrapping the h1 in the hybrid event hero component.

Open issue: #868 

I see there is config in `tailwind.config.cjs` specifically for `zIndex`, however, I was unable to get that to work as it needed to. So instead opted to use the [arbitrary values](https://tailwindcss.com/docs/z-index#arbitrary-values)

