### PR TITLE
fix: update broken url

### DIFF
--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -111,7 +111,7 @@
 				...m,
 				{
 					message: '🙌 We shipped again! 🎉 Check out newest features on THAT.us!!!',
-					url: '/changelog-missed'
+					url: '/releases/changelog-missed'
 				}
 			]);
 		}


### PR DESCRIPTION
Fixes #1126 

Url was missing `releases` in the url