### PR TITLE
fix: auth wrapper login redirect

### DIFF
--- a/src/_utils/security/auth.js
+++ b/src/_utils/security/auth.js
@@ -7,7 +7,7 @@ const { isNil, isEmpty } = lodash;
 export function initAuth0(config) {
 	const auth0 = origInitAuth0(config);
 	const getSession = auth0WrapperJson((req, res) => auth0.getSession(req, res));
-	const loginUrl = config?.routes?.login || '/login/';
+	const loginUrl = `${config?.baseURL}login`;
 
 	return {
 		getSession: getSession,


### PR DESCRIPTION
dynamic redirect to login isn't working in production as login is a js page. you can't set rel=external on a redirect so I'm trying a fully qualified path.