### PR TITLE
fix: use event startdate for workshop

### DIFF
--- a/src/routes/events/_components/tickets/_Workshops.svelte
+++ b/src/routes/events/_components/tickets/_Workshops.svelte
@@ -2,7 +2,7 @@
 	export let event;
 
 	import { createEventDispatcher } from 'svelte';
-
+	import dayjs from 'dayjs';
 	import { Standard as StandardButton } from '$elements/buttons';
 	import { CheckFull } from '$elements/svgs';
 
@@ -76,7 +76,9 @@
 											<CheckFull height="h-4" width="h-4" />
 										</span>
 									</div>
-									<p class="ml-3 text-sm text-gray-700">Event Access Monday 1/17</p>
+									<p class="ml-3 text-sm text-gray-700">
+										Event Access {dayjs(event.startDate).format('dddd M/D')}
+									</p>
 								</li>
 
 								<li class="flex items-start lg:col-span-1">


### PR DESCRIPTION
Fixes #1225 

Monday 1/7 was hard coded into the component.

Changed to use event.startDate and format to similar style.

Assumption made that Start Date will be pre-conference workshop date.

This fixes both TX/2022 and WI/2022 existing, and any future events, even if Pre-Con isn't on a Monday.