### PR TITLE
chore: refactor favorites for always supplying id for cdn

### DIFF
--- a/src/_dataSources/api.that.tech/me/favorites/mutations.js
+++ b/src/_dataSources/api.that.tech/me/favorites/mutations.js
@@ -2,26 +2,29 @@ import gFetch from '$utils/gfetch';
 import { log } from '../../utilities/error';
 
 const favoriteFragment = `
-  fragment sessionFields on AcceptedSession {
+  fragment sessionFields on SessionFavorite {
     id
-		eventId
-    title
-    shortDescription
-    status
-    startTime
-    tags
-    communities
-    speakers {
+    session {
       id
-      firstName
-      lastName
-      profileImage
-      profileSlug
-      earnedMeritBadges {
+      eventId
+      title
+      shortDescription
+      status
+      startTime
+      tags
+      communities
+      speakers {
         id
-        name
-        image
-        description
+        firstName
+        lastName
+        profileImage
+        profileSlug
+        earnedMeritBadges {
+          id
+          name
+          image
+          description
+        }
       }
     }
   }
@@ -52,7 +55,7 @@ export default (fetch) => {
 		return client.mutation({ mutation: TOGGLE_FAVORITE, variables }).then(({ data, errors }) => {
 			if (errors) log({ errors, tag: 'TOGGLE_FAVORITE' });
 
-			return data?.sessions?.favoriting?.toggle;
+			return data?.sessions?.favoriting?.toggle?.session;
 		});
 	}
 

--- a/src/_dataSources/api.that.tech/me/favorites/queries.js
+++ b/src/_dataSources/api.that.tech/me/favorites/queries.js
@@ -2,27 +2,30 @@ import gFetch from '$utils/gfetch';
 import { log } from '../../utilities/error';
 
 const favoriteFragment = `
-  fragment sessionFields on AcceptedSession {
+  fragment sessionFields on SessionFavorite {
     id
-		eventId
-    title
-    shortDescription
-    status
-    startTime
-    tags
-    communities
-    speakers {
+    session {
       id
-      firstName
-      lastName
-      profileImage
-      profileSlug
-      earnedMeritBadges {
+      eventId
+      title
+      shortDescription
+      status
+      startTime
+      tags
+      communities
+      speakers {
         id
-        name
-        image
-        description
-      }
+        firstName
+        lastName
+        profileImage
+        profileSlug
+        earnedMeritBadges {
+          id
+          name
+          image
+          description
+        }
+      }  
     }
   }
 `;
@@ -53,6 +56,7 @@ export default (fetch) => {
 
 			let results = data?.sessions?.me?.favorites || [];
 
+			results = results.map((s) => ({ ...s.session }));
 			results = results.filter((s) => s).filter((s) => s.status === 'ACCEPTED');
 			results.sort((a, b) => new Date(a.startTime) - new Date(b.startTime));
 


### PR DESCRIPTION
Updates site for graph change on session favorites

pr breaking the site: thatconference/that-api-sessions#204

