### PR TITLE
refactor: checkin registration

### DIFF
--- a/src/routes/event/check-in/[eventName]/[year]/+page.svelte
+++ b/src/routes/event/check-in/[eventName]/[year]/+page.svelte
@@ -8,11 +8,11 @@
 	import RegistrationList from '../../_components/_RegistrationList.svelte';
 
 	let { registrations } = data;
-	const metaTags = ((title = 'Event Checkin - THAT') => ({
+	const metaTags = ((title = 'Event Check-In - THAT') => ({
 		title,
 		tags: seoMetaTags({
 			title,
-			description: 'Upcoming and Past Events at THAT',
+			description: 'Event check-in',
 			openGraph: {
 				type: 'website',
 				url: 'https://that.us/'

--- a/src/routes/event/check-in/_components/_CheckinModal.svelte
+++ b/src/routes/event/check-in/_components/_CheckinModal.svelte
@@ -23,12 +23,13 @@
 	async function handleCheckIn() {
 		waiting = true;
 
+		if (pinNumber === '') pinNumber = null;
 		const { result, message } = await checkIn(eventId, ticketId, pinNumber);
 
 		waiting = false;
 
 		if (result) {
-			returnPin = pinNumber;
+			returnPin = pinNumber ?? 'PIN opt-out';
 			dispatch('checkinCompleted');
 		} else {
 			checkInError = true;

--- a/src/routes/event/check-in/_components/_CheckinModal.svelte
+++ b/src/routes/event/check-in/_components/_CheckinModal.svelte
@@ -3,6 +3,7 @@
 	export let eventId;
 	export let title;
 	export let text;
+	export let returnPin;
 
 	import { createEventDispatcher } from 'svelte';
 	import { Circle3 } from 'svelte-loading-spinners';
@@ -27,6 +28,7 @@
 		waiting = false;
 
 		if (result) {
+			returnPin = pinNumber;
 			dispatch('checkinCompleted');
 		} else {
 			checkInError = true;

--- a/src/routes/event/check-in/_components/_EditCheckInModal.svelte
+++ b/src/routes/event/check-in/_components/_EditCheckInModal.svelte
@@ -4,6 +4,7 @@
 	export let title;
 	export let text;
 	export let isOwedShirt = false;
+	export let returnPin;
 
 	import { createEventDispatcher } from 'svelte';
 	import { Circle3 } from 'svelte-loading-spinners';
@@ -29,6 +30,7 @@
 		waiting = false;
 
 		if (result) {
+			returnPin = pinNumber;
 			dispatch('checkinUpdated');
 		} else {
 			checkInError = true;
@@ -44,6 +46,7 @@
 		waiting = false;
 
 		if (result) {
+			returnPin = 'PIN not set';
 			dispatch('checkinUpdated');
 		} else {
 			checkInError = true;

--- a/src/routes/event/check-in/_components/_EditCheckInModal.svelte
+++ b/src/routes/event/check-in/_components/_EditCheckInModal.svelte
@@ -30,7 +30,7 @@
 		waiting = false;
 
 		if (result) {
-			returnPin = pinNumber;
+			returnPin = pinNumber || 'PIN Removed';
 			dispatch('checkinUpdated');
 		} else {
 			checkInError = true;

--- a/src/routes/event/check-in/_components/_Ticket.svelte
+++ b/src/routes/event/check-in/_components/_Ticket.svelte
@@ -23,6 +23,8 @@
 	let ticketHolder = ticket.isAllocated ? allocatedTo : purchasedBy;
 	let checkInClicked = false;
 	let editCheckInClicked = false;
+	let displayPin = ticket.partnerPin ?? 'PIN not set';
+	let tempPin;
 </script>
 
 <div
@@ -64,7 +66,7 @@
 						</p>
 						<div class="mt-2 flex items-center space-x-2 text-sm text-gray-500">
 							<span class="rounded-full bg-green-300 py-1 px-8  font-extrabold text-white">
-								{ticket.partnerPin ? ticket.partnerPin : 'unassigned'}
+								{displayPin}
 							</span>
 						</div>
 					</div>
@@ -133,8 +135,10 @@
 		text="Please enter the user's pin."
 		eventId={ticket.event.id}
 		ticketId={ticket.id}
+		bind:returnPin={tempPin}
 		on:checkinCompleted={() => {
 			checkInClicked = false;
+			if (tempPin) displayPin = tempPin;
 		}}
 		on:close={() => (checkInClicked = false)} />
 {/if}
@@ -142,12 +146,14 @@
 {#if editCheckInClicked}
 	<EditCheckinModal
 		title="THAT Edit Check-In"
-		text="Revert or update a users checkin."
+		text="Revert or update a users check-in."
 		eventId={ticket.event.id}
 		ticketId={ticket.id}
 		isOwedShirt={!ticket.receivedSwag}
+		bind:returnPin={tempPin}
 		on:checkinUpdated={() => {
 			editCheckInClicked = false;
+			if (tempPin) displayPin = tempPin;
 		}}
 		on:close={() => (editCheckInClicked = false)} />
 {/if}

--- a/src/routes/event/check-in/_components/_Ticket.svelte
+++ b/src/routes/event/check-in/_components/_Ticket.svelte
@@ -102,7 +102,23 @@
 			</div>
 		</div>
 	</div>
-
+	{#if !ticket.hasCheckedIn && displayPin !== 'PIN not set'}
+		<div class="flex pt-6 pb-2">
+			<div class="flex items-center">
+				<div class="flex-shrink-0 pr-4">
+					<span
+						class="flex h-6 w-6 items-center justify-center rounded-full bg-green-500 bg-opacity-60">
+						<CheckFull height="h-4" width="w-4" />
+					</span>
+				</div>
+				<div>
+					<span class="text-gray-500">
+						Checked in. Reload page to perform further edits to this ticket.
+					</span>
+				</div>
+			</div>
+		</div>
+	{/if}
 	{#if ticket.hasCheckedIn}
 		<div class="flex pt-6 pb-2">
 			<div class="flex items-center">

--- a/src/routes/support/sponsors/forms/+page.svelte
+++ b/src/routes/support/sponsors/forms/+page.svelte
@@ -18,8 +18,8 @@
 		})
 	}))();
 
-	const txEventId = 'OlyDhUyrp2DI9babqZO9';
-	const wiEventId = 'w1ZQFzsSZzRuItVCNVmC';
+	const txEventId = 'THATConferenceTexas2023';
+	const wiEventId = 'THATConferenceWisconsin2023';
 </script>
 
 <Seo title={metaTags.title} tags={metaTags.tags} />
@@ -98,7 +98,9 @@
 							<h3>Important Event Links</h3>
 							<ul>
 								<li>
-									<a href={`/partners/leads/${txEventId}`} target="_blank">Lead Generation</a>
+									<a href={`/partners/leads/${txEventId}`} target="_blank" rel="noreferrer">
+										Lead Generation
+									</a>
 								</li>
 								<li>
 									<a href="/partners/my-network/" target="_blank">Lead Generation Results</a>


### PR DESCRIPTION
refactored to provide feedback when checking or changing partner pin
refactor the handling of updating pin to no pin value.
update text for consistency of terms (e.g. checkin vs. check-in)

The goal with this update was to provide some feedback to a person checking people in without getting into state hell of what is going on. A future refactoring thought is getting back an updated "ticket" object from the api on checkin which can update the values"
