### PR TITLE
fix: sourcemaps now uploaded to sentry on build

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,7 +8,10 @@
 			"$dataSources/*": ["./src/_dataSources/*"],
 			"$stores/*": ["./src/_stores/*"],
 			"$machines/*": ["./src/_machines/*"],
-			"$blog/*": ["./src/_blog/*"]
+			"$blog/*": ["./src/_blog/*"],
+			"$lib": ["src/lib"],
+			"$lib/*": ["src/lib/*"]
 		}
-	}
+	},
+	"extends": "./.svelte-kit/tsconfig.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "that-us",
-	"version": "3.1.1",
+	"version": "3.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "that-us",
-			"version": "3.1.1",
+			"version": "3.2.0",
 			"license": "GPL-3.0",
 			"devDependencies": {
 				"@auth0/nextjs-auth0": "^1.9.2",
@@ -79,7 +79,7 @@
 				"tailwindcss": "^3.2.0",
 				"uuid": "^9.0.0",
 				"vite": "^3.1.8",
-				"vite-plugin-sentry": "^1.1.6",
+				"vite-plugin-sentry": "^1.1.7",
 				"xstate": "^4.33.6",
 				"yup": "^0.32.11"
 			},
@@ -9202,9 +9202,9 @@
 			}
 		},
 		"node_modules/vite-plugin-sentry": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/vite-plugin-sentry/-/vite-plugin-sentry-1.1.6.tgz",
-			"integrity": "sha512-IgrIIl+VKwfLEoJ5O/8rplWmnkjdzqlBwmncWJH19mitr/v7SP7YnXlzv+vdAvxBo5eA8QPYx0J2i58NnaQ3fg==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/vite-plugin-sentry/-/vite-plugin-sentry-1.1.7.tgz",
+			"integrity": "sha512-V5WlWKbgul3udItDmvZHEzUw0TE2cehKLfcdR/G98PQ2LvweWDafVk4nmJpj1I7q70eeXWNoqmVq5Esde8c7XA==",
 			"dev": true,
 			"dependencies": {
 				"@sentry/cli": "^2.3.1"
@@ -9213,7 +9213,7 @@
 				"node": ">= 12"
 			},
 			"peerDependencies": {
-				"vite": "^2.6.0 || ^3.0.0"
+				"vite": "^2.6.0 || ^3.0.0 || ^4.0.0"
 			}
 		},
 		"node_modules/vue-eslint-parser": {
@@ -16095,9 +16095,9 @@
 			}
 		},
 		"vite-plugin-sentry": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/vite-plugin-sentry/-/vite-plugin-sentry-1.1.6.tgz",
-			"integrity": "sha512-IgrIIl+VKwfLEoJ5O/8rplWmnkjdzqlBwmncWJH19mitr/v7SP7YnXlzv+vdAvxBo5eA8QPYx0J2i58NnaQ3fg==",
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/vite-plugin-sentry/-/vite-plugin-sentry-1.1.7.tgz",
+			"integrity": "sha512-V5WlWKbgul3udItDmvZHEzUw0TE2cehKLfcdR/G98PQ2LvweWDafVk4nmJpj1I7q70eeXWNoqmVq5Esde8c7XA==",
 			"dev": true,
 			"requires": {
 				"@sentry/cli": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.1.1",
+	"version": "3.2.1",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",
@@ -94,7 +94,7 @@
 		"tailwindcss": "^3.2.0",
 		"uuid": "^9.0.0",
 		"vite": "^3.1.8",
-		"vite-plugin-sentry": "^1.1.6",
+		"vite-plugin-sentry": "^1.1.7",
 		"xstate": "^4.33.6",
 		"yup": "^0.32.11"
 	}

--- a/src/_utils/config.public.js
+++ b/src/_utils/config.public.js
@@ -8,7 +8,7 @@ function configMissing(configKey) {
 export default {
 	hostURL: env.PUBLIC_HOST_URL || 'https://that.us',
 	nodeEnv: env.NODE_ENV,
-	version: '3.1.1',
+	version: '3.2.1',
 	eventId: 'YWavA70szR8rxSwrLJaL',
 	eventSlug: 'thatus/daily',
 	api: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,31 +1,37 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig, loadEnv } from 'vite';
 import viteSentry from 'vite-plugin-sentry';
 import pkg from './package.json';
 
-const sentryConfig = {
-	url: 'https://sentry.io',
-	authToken: process.env.SENTRY_SRC_MAP_UPLOAD,
-	org: 'that-confernece',
-	project: 'thatus',
-	release: pkg.version,
-	deploy: {
-		env: 'production'
-	},
-	setCommits: {
-		auto: true
-	},
-	sourceMaps: {
-		include: ['./dist/assets'],
-		ignore: ['node_modules'],
-		urlPrefix: '~/assets'
-	}
-};
+const config = ({ mode }) => {
+	process.env = { ...process.env, ...loadEnv(mode, process.cwd(), '') };
 
-const config = {
-	plugins: [viteSentry(sentryConfig), sveltekit()],
-	build: {
-		sourcemap: true
-	}
+	const sentryConfig = {
+		url: 'https://sentry.io',
+		authToken: process.env.SENTRY_SRC_MAP_UPLOAD,
+		org: 'that-conference',
+		project: 'that-us',
+		release: pkg.version,
+		deploy: {
+			env: 'production'
+		},
+		setCommits: {
+			auto: true
+		},
+		sourceMaps: {
+			include: ['./.svelte-kit/output'],
+			ignore: ['node_modules']
+		},
+		cleanArtifacts: true,
+		debug: false
+	};
+
+	return defineConfig({
+		plugins: [sveltekit(), viteSentry(sentryConfig)],
+		build: {
+			sourcemap: true
+		}
+	});
 };
 
 export default config;


### PR DESCRIPTION
Fixes sourcemaps uploading to Sentry
`jsconfig.json` update per svelte runtime recommendations. 

Please note: as of this date the `@sentry/vite-plugin` does not work with Sveltekit. We'll continue with `vite-plugin-sentry`. 

ref: https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/174