### PR TITLE
fix: update emergency contact phone number regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "that-us",
-	"version": "3.2.0",
+	"version": "3.2.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "that-us",
-			"version": "3.2.0",
+			"version": "3.2.1",
 			"license": "GPL-3.0",
 			"devDependencies": {
 				"@auth0/nextjs-auth0": "^1.9.2",

--- a/src/routes/my/profiles/_components/emergencyContactForm.svelte
+++ b/src/routes/my/profiles/_components/emergencyContactForm.svelte
@@ -8,8 +8,8 @@
 			.string()
 			.trim()
 			.matches(
-				/^\+[1-9]\d{10,14}$/,
-				'Phone number must be in the following format (E.g. +13476748428)'
+				/^\+(?:[0-9] ?){6,14}[0-9]$/,
+				'Phone number must be in the following format: +13476748428, +493083050, etc.)'
 			)
 			.required('Please enter a phone number we can reach them at.'),
 		relationship: yup.string().trim().required('What is their relationship to you?'),
@@ -89,7 +89,7 @@
 						<div class="mt-4">
 							<label for="phoneNumber" class="block">
 								<span class="text-gray-700"
-									>What is the best number to contact them at? (E.g. +13476748428)</span>
+									>What is the best number to contact them at? (E.g. +13476748428, +493083050, etc.)</span>
 							</label>
 							<div class="relative">
 								<span
@@ -99,12 +99,12 @@
 							<MaskInput
 								name="phoneNumber"
 								alwaysShowMask
-								mask="+0 (000) 000 - 0000"
+								mask="+00000000000000"
 								size={20}
 								showMask
-								maskChar="_"
+								maskChar=""
 								class="form-input block w-full transition duration-150 ease-in-out sm:text-sm sm:leading-5"
-								value={emergencyContactInformation.phoneNumber || undefined}
+								value={emergencyContactInformation?.phoneNumber || undefined}
 								on:change={({ detail: { inputState } }) => {
 									if (inputState.unmaskedValue.length === 0) setValue('phoneNumber', null);
 									else setValue('phoneNumber', `+${inputState.unmaskedValue}`);

--- a/src/routes/speakers/_components/formSections/EmergencyContactInfo.svelte
+++ b/src/routes/speakers/_components/formSections/EmergencyContactInfo.svelte
@@ -7,7 +7,10 @@
 		phoneNumber: yup
 			.string()
 			.trim()
-			.matches(/^\+[1-9]\d{10,14}$/, 'Phone number must be in the following format: +13476748428)')
+			.matches(
+				/^\+(?:[0-9] ?){6,14}[0-9]$/,
+				'Phone number must be in the following format: +13476748428, +493083050, etc.)'
+			)
 			.required('Please enter a phone number we can reach them at.'),
 		relationship: yup.string().trim().required('What is their relationship to you?'),
 		travelingWithYou: yup.boolean().required('Are they traveling with you?')


### PR DESCRIPTION
New regex for international numbers
Update mask to support international numbers
fix form for when emergency contact is `null`
