### PR TITLE
refactor: add missing trailingSlash entries for svelte v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.2.1",
+	"version": "3.2.2",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",

--- a/src/_components/footer/Footer.svelte
+++ b/src/_components/footer/Footer.svelte
@@ -4,6 +4,7 @@
 	import { SocialLink } from '../social';
 	import socials from './socials';
 	import Newsletter from '../newsletter/Footer.svelte';
+	import { version } from '$app/environment';
 
 	import {
 		thatLinks,
@@ -140,7 +141,8 @@
 		<div>
 			<div class="mt-12 border-t border-gray-200 pt-8">
 				<p class="text-base text-gray-400 xl:text-center">
-					&copy; {dayjs().format('YYYY')} THAT&reg; All rights reserved.
+					&copy; {dayjs().format('YYYY')} THAT&reg; All rights reserved.<br />
+					<em>v{version}</em>
 				</p>
 			</div>
 		</div>

--- a/src/_utils/gfetch.js
+++ b/src/_utils/gfetch.js
@@ -67,7 +67,7 @@ function init(fetch) {
 	}
 
 	function secureQuery({ query, variables = {} }) {
-		const dynamicEndpoint = `${config.hostURL}/api/auth/proxy`;
+		const dynamicEndpoint = `${config.hostURL}/api/auth/proxy/`;
 
 		if (browser) {
 			loading.set(true);
@@ -99,7 +99,7 @@ function init(fetch) {
 	}
 
 	function mutation({ mutation, variables = {} }) {
-		let dynamicEndpoint = `${config.hostURL}/api/auth/proxy`;
+		let dynamicEndpoint = `${config.hostURL}/api/auth/proxy/`;
 
 		if (browser) {
 			loading.set(true);

--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -24,6 +24,8 @@ async function queryMe(accessToken) {
 		.then((results) => results.data.members?.me);
 }
 
+export const trailingSlash = 'always';
+
 export async function load({ request, locals }) {
 	const auth0Session = await auth0.getSession(request);
 

--- a/src/routes/api/auth/callback/+server.js
+++ b/src/routes/api/auth/callback/+server.js
@@ -1,5 +1,7 @@
 import auth0 from '$utils/security/server';
 
+export const trailingSlash = 'always';
+
 export function GET({ request }) {
 	return auth0.handleCallback(request);
 }

--- a/src/routes/api/auth/me/+server.js
+++ b/src/routes/api/auth/me/+server.js
@@ -1,5 +1,7 @@
 import auth0 from '$utils/security/server';
 
+export const trailingSlash = 'always';
+
 export function GET({ request }) {
 	return auth0.handleProfile(request, { refetch: true });
 }

--- a/src/routes/api/auth/proxy/+server.js
+++ b/src/routes/api/auth/proxy/+server.js
@@ -4,6 +4,8 @@ import fetch from 'isomorphic-fetch';
 import config from '$utils/config.public';
 import * as Sentry from '@sentry/svelte';
 
+export const trailingSlash = 'always';
+
 export async function POST({ request }) {
 	const body = await request.json();
 

--- a/src/routes/api/auth/signup/+server.js
+++ b/src/routes/api/auth/signup/+server.js
@@ -1,5 +1,7 @@
 import auth0 from '$utils/security/server';
 
+export const trailingSlash = 'always';
+
 export function GET({ request }) {
 	return auth0.handleLogin(request, {
 		authorizationParams: {

--- a/src/routes/api/og-image/[id]/+server.js
+++ b/src/routes/api/og-image/[id]/+server.js
@@ -2,6 +2,8 @@ import config from '$utils/config.public';
 
 const baseHostImage = 'https://that.imgix.net/og-image';
 
+export const trailingSlash = 'always';
+
 export async function GET({ params }) {
 	let { id } = params;
 	const response = await fetch(`${baseHostImage}/${id}.png`);

--- a/src/routes/api/releases.json/+server.js
+++ b/src/routes/api/releases.json/+server.js
@@ -1,5 +1,7 @@
 import { json } from '@sveltejs/kit';
 
+export const trailingSlash = 'always';
+
 export async function GET({ _query, _locals }) {
 	return json({
 		stuff: 'asdf'

--- a/src/routes/login/+server.js
+++ b/src/routes/login/+server.js
@@ -1,5 +1,7 @@
 import auth0 from '$utils/security/client';
 
+export const trailingSlash = 'always';
+
 export function GET({ request }) {
 	const returnTo = request.url.searchParams?.get('returnTo') || '/';
 	return auth0.handleLogin(request, { returnTo });

--- a/src/routes/logout/+server.js
+++ b/src/routes/logout/+server.js
@@ -1,5 +1,7 @@
 import auth0 from '$utils/security/client';
 
+export const trailingSlash = 'always';
+
 export function GET({ request }) {
 	return auth0.handleLogout(request);
 }


### PR DESCRIPTION
v3.2.2
refactor: add missing trailingSlash entries for svelte v1
versioning set using package.json

that.us now reads version from `package.json` and uses that version for sentry maps. 