### PR TITLE
fix: redirects to jit.si until we have a better solution

### DIFF
--- a/src/routes/join/[activityId]/+page.js
+++ b/src/routes/join/[activityId]/+page.js
@@ -16,9 +16,5 @@ export async function load({ params, fetch }) {
 			throw redirect(302, `/join/access-denied/?id=${activityId}`);
 		}
 	}
-
-	return {
-		activityId,
-		activityDetails
-	};
+	throw redirect(302, `https://meet.jit.si/that-${activityId}`);
 }


### PR DESCRIPTION
Well, you can't embed Jitsi anymore. So we're broke. 

In the meantime, we just redirected the session to meet.jit.si until we figure out a viable solution.