### PR TITLE
fix: favorites file downloading as txt, not csv

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",

--- a/src/routes/my/favorites/+page.svelte
+++ b/src/routes/my/favorites/+page.svelte
@@ -60,7 +60,7 @@
 		];
 
 		const tableKeys = Object.keys(csvdata[0]);
-		csvGenerator(csvdata, tableKeys, tableHeader, 'THAT-My-Favorites');
+		csvGenerator(csvdata, tableKeys, tableHeader, 'THAT-My-Favorites.csv');
 	};
 </script>
 


### PR DESCRIPTION
v3.3.1
Fixes issue were file was downloading as txt not csv. 