### PR TITLE
feat: that field guide, session layout improvements

### DIFF
--- a/mdsvex.config.js
+++ b/mdsvex.config.js
@@ -2,6 +2,7 @@ import path from 'path';
 import autolinkHeadings from 'rehype-autolink-headings';
 import slugPlugin from 'rehype-slug';
 import readingTime from 'remark-reading-time';
+import { s } from 'hastscript';
 import preview, { textFormatter, htmlFormatter } from 'remark-preview';
 
 export default {
@@ -37,7 +38,26 @@ export default {
 		[
 			autolinkHeadings,
 			{
-				behavior: 'prepend'
+				behavior: 'prepend',
+				// properties: {
+				// 	ariaHidden: true,
+				// 	tabIndex: -1,
+				// 	class: ''
+				// },
+				// on auto-headings insert svg along with anchor slug
+				content: s(
+					'svg',
+					{
+						xmlns: 'http://www.w3.org/2000/svg',
+						viewBox: '0 0 16 16',
+						width: 16,
+						height: 16,
+						class: 'mr-2 inline rounded-full hover:bg-gray-400'
+					},
+					s('path', {
+						d: 'm7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z'
+					})
+				)
 			}
 		]
 	]

--- a/mdsvex.config.js
+++ b/mdsvex.config.js
@@ -39,12 +39,8 @@ export default {
 			autolinkHeadings,
 			{
 				behavior: 'prepend',
-				// properties: {
-				// 	ariaHidden: true,
-				// 	tabIndex: -1,
-				// 	class: ''
-				// },
 				// on auto-headings insert svg along with anchor slug
+				// may be better to reference a global svg
 				content: s(
 					'svg',
 					{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "that-us",
-	"version": "3.3.0",
+	"version": "3.7.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "that-us",
-			"version": "3.3.0",
+			"version": "3.7.0",
 			"license": "GPL-3.0",
 			"devDependencies": {
 				"@auth0/nextjs-auth0": "^1.9.2",
@@ -39,6 +39,7 @@
 				"eslint-plugin-svelte3": "^4.0.0",
 				"fetch-retry": "^5.0.3",
 				"fuse.js": "^6.6.2",
+				"hastscript": "^7.2.0",
 				"husky": "^8.0.1",
 				"ical-generator": "^3.6.0",
 				"install": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.6.1",
+	"version": "3.7.0",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"eslint-plugin-svelte3": "^4.0.0",
 		"fetch-retry": "^5.0.3",
 		"fuse.js": "^6.6.2",
+		"hastscript": "^7.2.0",
 		"husky": "^8.0.1",
 		"ical-generator": "^3.6.0",
 		"install": "^0.13.0",

--- a/src/_blog/posts/2021-10-21-what-is-that/index.md
+++ b/src/_blog/posts/2021-10-21-what-is-that/index.md
@@ -9,26 +9,25 @@ layout: blog
 ---
 
 <script>
-	export let slug;
-	
-	import image from '$blog/image';
-	import { Standard as StandardLink } from '$elements/links';
+ export let slug;
+ 
+ import image from '$blog/image';
+ import { Standard as StandardLink } from '$elements/links';
 
-
-	const { cdnUrl } = image(slug);
+ const { cdnUrl } = image(slug);
 
 </script>
 
 ## Hey Clark, help me understand; THAT, THAT Conference, and THAT Online, what is all this?
 
-## I don't understand.
+## I don't understand
 
 This question came through our webchat during last Friday's THAT Online, and it's the spirit of today's newsletter. Over the past two years, a lot has changed, we've tried to adapt, innovate, and better service all Geeks, but we're not always the best at the words part of things, so let's dive in.
 
 ## What is THAT?
 
 <div class="w-full grid place-content-center">
-	<img class="w-[300px] lazyload" src="{cdnUrl('THAT-Wide.png')}" alt="THAT Logo"/>
+ <img class="w-[300px] lazyload" src="{cdnUrl('THAT-Wide.png')}" alt="THAT Logo"/>
 </div>
 
 Let's start by defining what exactly **THAT** is. The most straightforward answer, well, everything. By now, you've heard me say a community goes far beyond one's time together at THAT Conference; it exists every day. No doubt something special happens when geeks get together, it's essential, but it also shouldn't ever stop there. Our mission is to help you grow, support you, and grow the communities that surround every one of us. We also want to do all this every day of the year.
@@ -44,13 +43,13 @@ We set out to build a platform that would help us all. It should let us see one 
 **It's also free to use.**
 
 <div class="py-10 w-full grid place-content-center">
-	<StandardLink href="/activities/">View Activities</StandardLink>
+ <StandardLink href="/activities/">View Activities</StandardLink>
 </div>
 
 ## What is THAT Conference?
 
 <div class="w-full grid place-content-center">
-	<img class="w-[300px] lazyload" src={cdnUrl("THAT-Conference.png")} alt="THAT Logo" />
+ <img class="w-[300px] lazyload" src={cdnUrl("THAT-Conference.png")} alt="THAT Logo" />
 </div>
 
 Now without question, you found us because of THAT Conference. Looking back over the past ten years, it's crazy amazing to reflect on just how much tech has changed, and like tech, THAT Conference has grown in every aspect. THAT Conference is still and will always be at the core of our mission. Getting geeks together to support, teach, expand their networks, and grow their businesses is our passion.
@@ -63,7 +62,7 @@ Unlike other hybrid events, ours intentionally do not intermingle. We want to re
 
 ### What is AT THAT Conference?
 
-Everything you've come to know about THAT Conference remains the same. Simply put, you're physically AT THAT Conference. Summer Camp For Geeks.
+Everything you've come to know about THAT Conference remains the same. Simply put, you're physically AT THAT Conference. Summer Camp For Geeks®.
 
 ### What is ON THAT Conference?
 
@@ -86,13 +85,13 @@ Nope in fact it's quite the opposite. We're adding a winter event in Round Rock 
 In summary - when you think of THAT Conference you know it's one of our keystone events which is now a combination of **AT** && **ON THAT**.
 
 <div class="py-10 w-full grid place-content-center">
-	<StandardLink href="https://thatconference.com">THAT Conference</StandardLink>
+ <StandardLink href="https://thatconference.com">THAT Conference</StandardLink>
 </div>
 
 ## What is THAT Online?
 
 <div class="w-full grid place-content-center">
-	<img class="w-[300px] lazyload" src={cdnUrl("that-online.png")} alt="THAT Logo" />
+ <img class="w-[300px] lazyload" src={cdnUrl("that-online.png")} alt="THAT Logo" />
 </div>
 
 That leads us to THAT Online. Much like THAT Conference's ON THAT, THAT Online is a monthly manifestation of that same spirit. A monthly unconference on the 15th of every month for 24 hours. There is no call for speakers and we all drive the schedule based on what we submit and when we schedule it.
@@ -108,7 +107,7 @@ You do not need to wait for an event to use [THAT.us](https://THAT.us), remember
 Honestly, this pandemic we've all been hiking through opened the door for us to really do what we're passionate about which is help geeks. Sure we like to write code, but we like connecting people more.
 
 <div class="py-10 w-full grid place-content-center">
-	<StandardLink href="/events/">See the upcoming events</StandardLink>
+ <StandardLink href="/events/">See the upcoming events</StandardLink>
 </div>
 
 ## What is THAT Membership?
@@ -116,10 +115,10 @@ Honestly, this pandemic we've all been hiking through opened the door for us to 
 If you can't tell, we've been busy, and we hope you love all that you see. Earlier this year we introduced a Membership program. We introduced this as a direct way to support us and in turn support the community at large. You can read more about it here: [https://that.us/membership/](https://that.us/membership/) and note there are some benefit improvements coming.
 
 <div class="py-10 w-full grid place-content-center">
-	<StandardLink href="/membership/">Join Today</StandardLink>
+ <StandardLink href="/membership/">Join Today</StandardLink>
 </div>
 
-## Mark your Calendars!
+## Mark your Calendars
 
 ### Texas
 

--- a/src/_blog/posts/2023-wi-three-months-until-that/index.md
+++ b/src/_blog/posts/2023-wi-three-months-until-that/index.md
@@ -1,0 +1,59 @@
+---
+date: 2023-05-09
+articleType: Article
+title: 3 months until THAT Conference
+description: what is lovely and maybe even the most important, the conversations now in person are far deeper than ever before. That right there is what THAT is all about. Yes, we come to learn from other practitioners, but we grow as a family when we bond.
+heroImage: hero.jpg
+authorSlug: clark
+layout: blog
+---
+
+<script>
+ export let slug;
+
+ import SponsorSimple from '$components/SponsorSimple.svelte';
+ import image from '$blog/image';
+ import { Standard as StandardLink } from '$elements/links';
+
+ const { cdnUrl } = image(slug);
+
+</script>
+
+Right now, it's 3 am, and I can't get THAT Conference off my mind. That might be the worst email opening line ever, but it's true and dark outside.
+
+But seriously, I can't stop thinking about THAT. I woke up, grabbed my laptop, and started writing.
+
+I have one goal; foster the best community of geeks and geeklings on this planet, both online and in person. THAT Conference is without question the only conference that is also a community, and it's because of people like you.
+
+The past four events we've held in both Texas and Wisconsin have been very special, not because of the shirts, the bbq, the walking tacos ( they were fire, actually not literally on fire, never mind), or even my silly tomfoolery, but because of the people who came and what they did. Let me say that again, the people, YOU!
+
+Why is it so different now, Clark?
+
+The pandemic altered our (the collective, and well, ours too) course. The course of what? Well, it depends on who you are. In some areas of life, we got complacent, while in others areas, they were yet to be explored. If I'm being positive Panda, we can all agree it dropped a big ole bag of change on our doorsteps.
+
+Regardless, after the past four events now in two different states, I can say this:
+
+We need each other more than most care to admit.
+Friendships and networks become cemented when people are together.
+Online !== In Person
+Life continues.
+But, bUt, BUUT, what is lovely and maybe even the most important, the conversations now in person are far deeper than ever before. That right there is what THAT is all about. Yes, we come to learn from other practitioners, but we grow as a family when we bond. This isn't to say I don't believe online doesn't have a place, far from it. We're building THAT.us for precisely that, but neither can replace the other.
+
+And yet, here we are, 13 years and a global pandemic later, we still haven't given up. The tech might be different, HDMI is now the standard, and once again, in less than three months, I'll take the stage with butterflies in my stomach and say Good Morning, Campers.
+
+I am beyond excited to have that opportunity and hope to see you there.
+
+Come for the learning, and stay for the community.
+
+Clark
+
+THAT Conference  
+The only conference that's a community!
+
+### Check out our Sponsors
+
+We can't do any of this without your support and the support of our sponsors. Make sure to visit the companies investing in our community and helping make all of this a reality.
+
+<div class="max-w-7xl mx-auto">
+ <SponsorSimple isBlogLayout={true} eventSlug="wi/2023" />
+</div>

--- a/src/_components/activities/ActivityDetails.svelte
+++ b/src/_components/activities/ActivityDetails.svelte
@@ -65,19 +65,29 @@
 		prerequisites,
 		takeaways,
 		agenda,
-		supportingArtifacts
+		supportingArtifacts,
+		primaryCategory
 	} = activity;
 
 	let dropDownKeyValuePairs = getContext('DROP_DOWN_KEY_VALUE_PAIRS');
 	const isDailyActivity = config.eventId === eventId;
 
 	// Enum Lookups
-	let sessionTargetLocation =
-		dropDownKeyValuePairs.targetLocation.options.find((x) => x.value === targetLocation)?.label ||
-		'Online';
 	let sessionTargetLocationIcon =
 		targetLocation === 'EITHER' ? exchange : targetLocation === 'IN_PERSON' ? user : globe;
 	let sessionType = dropDownKeyValuePairs.sessionType.options.find((x) => x.value === type)?.label;
+	// Display replacements
+	if (type === 'REGULAR') {
+		if (primaryCategory === 'THAT') {
+			sessionType = 'A THAT Conference Activity';
+		} else {
+			sessionType = sessionType.replace('60', durationInMinutes.toString());
+		}
+	}
+	if (type === 'KEYNOTE') {
+		sessionType = sessionType.replace('90', durationInMinutes.toString());
+	}
+
 	let sessionLocationDestination = dropDownKeyValuePairs.sessionLocationDestinations.options.find(
 		(x) => x.value === sessionLocation?.destination
 	)?.label;
@@ -369,13 +379,11 @@
 					<!-- Start Time -->
 					<p class="text-base text-gray-700  sm:mx-auto sm:text-lg md:text-xl lg:mx-0">
 						{#if durationInMinutes > 0}
+							{dayjs(startTime).format('dddd, MMMM D, YYYY - h:mm A z')}, for
+							{dayjs.duration(durationInMinutes, 'minutes').as('hours')}
 							{#if durationInMinutes <= 60}
-								{dayjs(startTime).format('dddd, MMMM D, YYYY - h:mm A z')}, for
-								{dayjs.duration(durationInMinutes, 'minutes').as('hours')}
 								hour.
 							{:else}
-								{dayjs(startTime).format('dddd, MMMM D, YYYY - h:mm A z')}, for
-								{dayjs.duration(durationInMinutes, 'minutes').as('hours')}
 								hours.
 							{/if}
 						{/if}
@@ -384,9 +392,7 @@
 					<!-- Location -->
 					<p
 						class="mt-1 text-base text-gray-700 sm:mx-auto sm:mt-2 sm:text-lg md:mt-1 md:text-xl lg:mx-0">
-						<Icon
-							data={sessionTargetLocationIcon}
-							class="mr-2 h-4 w-4 pb-0.5" />{sessionTargetLocation}
+						<Icon data={sessionTargetLocationIcon} class="mr-2 h-4 w-4 pb-0.5" />
 						{sessionType}
 					</p>
 

--- a/src/_dataSources/api.that.tech/sessions.js
+++ b/src/_dataSources/api.that.tech/sessions.js
@@ -20,6 +20,7 @@ const coreSessionFields = `
 		slug
 		communities
 		category
+		primaryCategory
 		targetLocation
 		location {
 			destination

--- a/src/_elements/modals/Action.svelte
+++ b/src/_elements/modals/Action.svelte
@@ -30,7 +30,7 @@
 							{title}
 						</h3>
 						<div class="mt-2">
-							<p class="text-sm leading-5 text-gray-500">{text}</p>
+							<p class="text-sm leading-5 text-gray-500">{@html text}</p>
 						</div>
 						<div class="mt-8">
 							<slot />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -96,7 +96,7 @@
 	}
 
 	:global(.prose a:hover) {
-		color: #ffffff;
+		color: #f3f4f6;
 	}
 
 	:global(.lineBreaks) {

--- a/src/routes/_root/components/hero.svelte
+++ b/src/routes/_root/components/hero.svelte
@@ -7,7 +7,7 @@
 		<div class="flex flex-col space-y-24 lg:grid lg:grid-cols-7">
 			<div class="col-span-4">
 				<h2 class="font-extrabold uppercase tracking-wider text-thatRed-500 antialiased">
-					CAMP FOR GEEKS
+					SUMMER CAMP FOR GEEKS®
 				</h2>
 				<h1 class="mt-6 text-5xl font-bold text-thatBlue-700 antialiased">
 					Howdy. We’re a full-stack, tech-obsessed community of fun, code-loving humans who share

--- a/src/routes/call-for-counselors/[event]/[year]/+page.svelte
+++ b/src/routes/call-for-counselors/[event]/[year]/+page.svelte
@@ -91,7 +91,7 @@
 				<div class="col-span-5">
 					<h3
 						class="text-center text-4xl font-extrabold uppercase tracking-wide text-white sm:text-left">
-						Summer Camp for Geeks
+						Summer Camp for Geeks®
 					</h3>
 				</div>
 

--- a/src/routes/orders/_components/_Cart.svelte
+++ b/src/routes/orders/_components/_Cart.svelte
@@ -6,6 +6,7 @@
 
 	import config from '$utils/config.public';
 	import { Cart as CartModal } from '$elements/modals';
+	import { Action as ActionModal } from '$elements/modals';
 	import { Standard as StandardButton } from '$elements/buttons';
 	import { Standard as StandardLink } from '$elements/links';
 	import orderMutations from '$dataSources/api.that.tech/orders/mutations';
@@ -99,6 +100,11 @@
 
 		send('REPLACE_CART', eventData);
 	}
+
+	let activateRefundPolicyModal = false;
+	function openRefundPolicyModal(showModal) {
+		activateRefundPolicyModal = showModal;
+	}
 </script>
 
 <svelte:head>
@@ -179,6 +185,16 @@
 	</section>
 {:else}
 	<section class="flex flex-col space-y-8">
+		{#if activateRefundPolicyModal === true}
+			<ActionModal
+				title="Refund Policy"
+				text="Ticket refunds will not be issued on any ticket <span class='font-bold'>30 days</span> before the event or thereafter. Prior to that, a $30.00 (per ticket) processing fee will be applied to each attendee ticket refund and a $10.00 (per ticket) processing fee will be applied to each family ticket refund. Memberships are non-refundable.">
+				<div class="flex justify-center space-x-6">
+					<StandardButton on:click={() => openRefundPolicyModal(false)}>Cancel</StandardButton>
+					<StandardButton on:click={handleCheckout}>Go Checkout</StandardButton>
+				</div>
+			</ActionModal>
+		{/if}
 		<div class="relative">
 			<div class="absolute inset-0 flex items-center" aria-hidden="true">
 				<div class="w-full border-t border-gray-300" />
@@ -260,17 +276,11 @@
 		</div>
 
 		<div class="flex justify-end ">
-			<p class="text-sm text-gray-500">
-				Refunds will not be issued on any ticket <span class="font-bold">30 days</span> before the event
-				or thereafter. Prior to that, a $30.00 (per ticket) processing fee will be applied to each attendee
-				ticket refund and a $10.00 (per ticket) processing fee will be applied to each family ticket
-				refund.
-			</p>
 			{#if $state.matches('verification.verified')}
 				<div class="flex space-x-4">
 					<StandardButton on:click={() => history.back()}>Continue Shopping</StandardButton>
-
-					<StandardButton on:click={handleCheckout}>Continue to Complete Purchase</StandardButton>
+					<StandardButton on:click={() => openRefundPolicyModal(true)}
+						>Continue to Complete Purchase</StandardButton>
 				</div>
 			{:else}
 				<div

--- a/src/routes/orders/_components/_Cart.svelte
+++ b/src/routes/orders/_components/_Cart.svelte
@@ -259,7 +259,13 @@
 			</div>
 		</div>
 
-		<div class="flex justify-end">
+		<div class="flex justify-end ">
+			<p class="text-sm text-gray-500">
+				Refunds will not be issued on any ticket <span class="font-bold">30 days</span> before the event
+				or thereafter. Prior to that, a $30.00 (per ticket) processing fee will be applied to each attendee
+				ticket refund and a $10.00 (per ticket) processing fee will be applied to each family ticket
+				refund.
+			</p>
 			{#if $state.matches('verification.verified')}
 				<div class="flex space-x-4">
 					<StandardButton on:click={() => history.back()}>Continue Shopping</StandardButton>
@@ -268,7 +274,7 @@
 				</div>
 			{:else}
 				<div
-					class="rounded-md bg-gray-200 px-8 py-2 text-base font-medium leading-6 text-white shadow md:px-10 md:text-lg">
+					class="whitespace-nowrap rounded-md bg-gray-200 px-8 py-2 text-base font-medium leading-6 text-white shadow md:px-10 md:text-lg">
 					Purchase Now
 				</div>
 			{/if}

--- a/src/routes/orders/_components/_Cart.svelte
+++ b/src/routes/orders/_components/_Cart.svelte
@@ -191,7 +191,7 @@
 				text="Ticket refunds will not be issued on any ticket <span class='font-bold'>30 days</span> before the event or thereafter. Prior to that, a $30.00 (per ticket) processing fee will be applied to each attendee ticket refund and a $10.00 (per ticket) processing fee will be applied to each family ticket refund. Memberships are non-refundable.">
 				<div class="flex justify-center space-x-6">
 					<StandardButton on:click={() => openRefundPolicyModal(false)}>Cancel</StandardButton>
-					<StandardButton on:click={handleCheckout}>Go Checkout</StandardButton>
+					<StandardButton on:click={handleCheckout}>Agree and Continue</StandardButton>
 				</div>
 			</ActionModal>
 		{/if}
@@ -280,7 +280,7 @@
 				<div class="flex space-x-4">
 					<StandardButton on:click={() => history.back()}>Continue Shopping</StandardButton>
 					<StandardButton on:click={() => openRefundPolicyModal(true)}
-						>Continue to Complete Purchase</StandardButton>
+						>Agree and Continue</StandardButton>
 				</div>
 			{:else}
 				<div

--- a/src/routes/sponsorships/apply/+page.svelte
+++ b/src/routes/sponsorships/apply/+page.svelte
@@ -44,7 +44,7 @@
 				<div class="flex">
 					<div class="w-1/2">
 						<div class="flex h-full flex-col justify-center space-y-6 text-white">
-							<div class="text-2xl font-bold">Summer Camp For Geeks</div>
+							<div class="text-2xl font-bold">Summer Camp For Geeks®</div>
 							<p class="prose-xl text-white">
 								THAT Conference is the “Summer Camp for Geeks” that combines technology, networking,
 								social events and exposure in an inspirational, family friendly environment at the

--- a/src/routes/support/that-field-guide/+page.md
+++ b/src/routes/support/that-field-guide/+page.md
@@ -6,7 +6,7 @@ layout: support
 ---
 
 <div class="max-w-prose mx-auto">
-  <div class="prose prose-lg text-gray-500">
+  <div class= "prose prose-lg text-gray-500">
 
 ## Welcome
 
@@ -16,7 +16,7 @@ Last updated on **June 8th, 2023**
 
 ## Registration
 
-When you arrive at camp stop down at the Registration Desk and check in. This is where you'll get your badge and swag. The Registration Desk remains open throughout the day to answer questions. There is also a lost and found.
+When you arrive at camp stop down at the Registration Desk located in the convention center and check in. This is where you'll get your badge and swag. The Registration Desk remains open throughout the day to answer questions. There is also a lost and found.
 
 ### Hugs, Handshakes, and Waves
 
@@ -32,7 +32,7 @@ Yes, we understand while you're at the Kalahari and THAT Conference there are a 
 
 - The **Kalahari Wristband** is needed for the waterpark during the day, to get in your room, etc.
 - You DON'T need the Kalahari wristband for the THAT Conference Waterpark Party, bring your conference badge to get in.
-- You need to wear your **THAT Conference Food Bracelet**. Keep it on, if you lose it, it cannot be replaced.
+- You need to wear your **THAT Conference Food Bracelet** and present it at every meal. Keep it on: if you lose it, it cannot be replaced.
 - The **Campmate and Geekling food wristbands** only need to be worn for the THAT Conference Wednesday night dinner Pig Roast (WI) / BBQ (TX)
 
 ### THAT Ranger Station
@@ -47,7 +47,7 @@ With over 100 sessions, activities and Open Spaces sessions, keeping track of it
 
 ### Favorites
 
-By clicking on the ❤️ heart on a session, it adds this session to your [favorites](/my/favorites/). Favoriting sessions helps in many ways. It provides you with a list of all your favorite sessions. You'll receive an email notification whenever there is a change to a session's room or time. It also informs us how interested people are in a session so we can ensure there is a large enough room for it.
+By clicking on the ❤️ heart on a session, it adds this session to your [favorites](/my/favorites/). Favoriting sessions help in many ways. It provides you with a list of all your favorite sessions. You'll receive an email notification whenever there is a change to a session's room or time. It also informs us how interested people are in a session so we can ensure there is a large enough room for it.
 
 You can view a list of all of your favorites on the [My Favorites](/my/favorites/) page. Click the **[Subscribe](/support/my-favorites-icalendar/)** button at the top of the page for instructions on how to add your favorites to your calendar. There is also a button to download a CSV file of your favorites.
 
@@ -59,11 +59,11 @@ That's right, all restaurants and stands in the Kalahari are now cashless. The o
 
 ### 10% Discount at many restaurants
 
-The Kalahari provides the "Tree People" a 10% discount at many of the restaurants in the Kalahari. You'll need to show them your badge for the discount. We recommend you ask before ordering to ensure the particular restaurant you're at provides this discount.
+The Kalahari provides the "Tree People" a 10% discount at many of the restaurants in the Kalahari. You'll need to show them your badge for the discount. We recommend you ask before ordering to ensure the particular restaurant you're at provides this discount. The discount does not include alcohol.
 
 ## Mess Hall
 
-The Mess Hall is our main gathering place. This is where you'll find conference-provided meals, keynotes and special activities like THAT Wildlife. Oh and of course bacon 🥓! All family and attendees are welcome in the Mess Hall during meal times. You must have a food wristband to get food from the food buffet lines.
+The Mess Hall is our main gathering place. This is where you'll find conference-provided meals, keynotes and special activities like THAT Game Night. All family and attendees are welcome in the Mess Hall during meal times. You must have a food wristband to get food from the food buffet lines.
 
 ### Dietary Restrictions
 
@@ -77,7 +77,7 @@ Interested in discussing a topic or sharing an experience with peers? Want to cu
 
 ### Open Spaces Kick-Off
 
-After lunch on Tuesday around 12:00 will be the Open Spaces kick-off where we'll explain how Open Spaces works and start getting items on the Open Space's boards. we can't wait to see what you add to THAT Conference.
+After lunch on Tuesday around 12:00 will be the Open Spaces kick-off where we'll explain how Open Spaces works and start getting items on the Open Space's boards. We can't wait to see what you add to THAT Conference.
 
 ## Sponsors and Data Collection
 

--- a/src/routes/support/that-field-guide/+page.md
+++ b/src/routes/support/that-field-guide/+page.md
@@ -1,6 +1,7 @@
 ---
-title: THAT Field Guide
-description: Camp field guide to help you find your way
+title: THAT FIELD GUIDE
+preText: Finding Your Way
+description: THAT camp field guide to help you find your way
 layout: support
 ---
 
@@ -15,55 +16,88 @@ Last updated on **June 8th, 2023**
 
 ## Registration
 
-When you arrive at camp stop down at the Registration Desk and check-in. This is where you'll get your badge and swag. The Registration Desk remains open through the day to answer questions. There is also a lost and found.
+When you arrive at camp stop down at the Registration Desk and check in. This is where you'll get your badge and swag. The Registration Desk remains open throughout the day to answer questions. There is also a lost and found.
 
 ### Hugs, Handshakes, and Waves
 
 In these special times not everyone may be comfortable with handshakes or hugs, so to help remove the uneasiness of it we've come up with a simple system using **lanyard colors** ❤️ 💛 💚
 
 - **Red lanyard** indicates the person prefers no physical contact, aka. waves.
-- **Yellow lanyard** indicates the person limited contact and a handshake is okay.
+- **Yellow lanyard** indicates the person prefers limited contact and a handshake is okay.
 - **Green lanyard** indicates the person is okay with personal contact and a hug is acceptable.
+
+### So Many Wristbands 😵‍💫
+
+Yes, we understand while you're at the Kalahari and THAT Conference there are a lot of needed wristbands. Hopefully, this will remove some confusion.
+
+- The **Kalahari Wristband** is needed for the waterpark during the day, to get in your room, etc.
+- You DON'T need the Kalahari wristband for the THAT Conference Waterpark Party, bring your conference badge to get in.
+- You need to wear your **THAT Conference Food Bracelet**. Keep it on, if you lose it, it cannot be replaced.
+- The **Campmate and Geekling food wristbands** only need to be worn for the THAT Conference Wednesday night dinner Pig Roast (WI) / BBQ (TX)
 
 ### THAT Ranger Station
 
-By Tuesday afternoon, once most people are checked in the registration Desk turns into THAT Ranger Station where a staff member will be available during all session hours. Sometimes we may even be able to answer your questions. You'll also find the **Lost and Found** at THAT Ranger Station.
+After Tuesday morning the registration Desk turns into THAT Ranger Station where a staff member will be available during all session hours. Sometimes we may even be able to answer your questions and will certainly keep checking people in. You'll also find the **Lost and Found** at THAT Ranger Station.
 
 ## Schedule and Favorites
 
 ### Schedule
 
-With over 100 sessions, activities and Open Spaces sessions, keeping track of it all can be quite challenging. All regular sessions and event activities are listed in the schedule [here](/activities/). All the Open Spaces sessions are managed on the Open Spaces boards located in the Mess Hall.
+With over 100 sessions, activities and Open Spaces sessions, keeping track of it all can be quite challenging. All regular sessions and THAT Conference activities are listed in the schedule [here](/activities/). All the Open Spaces sessions are managed on the Open Spaces boards located in the Open Spaces room.
 
 ### Favorites
 
-By clicking on the ❤️ heart on a session, it adds this session to your [favorites](/my/favorites/). Favoriting sessions helps in may ways. You'll receive an email notifications whenever there is a change to session room or time. It also allows us how interested people are in a session to ensure there is a large enough room allocated.
+By clicking on the ❤️ heart on a session, it adds this session to your [favorites](/my/favorites/). Favoriting sessions helps in many ways. It provides you with a list of all your favorite sessions. You'll receive an email notification whenever there is a change to a session's room or time. It also informs us how interested people are in a session so we can ensure there is a large enough room for it.
 
-You can view a list of all of your favorites at [https://that.us/my/favorites](/my/favorites/). Click the **[Subscribe](/support/my-favorites-icalendar/)** button at the top of the page for instructions on how to add your favorites to your calendar.
+You can view a list of all of your favorites on the [My Favorites](/my/favorites/) page. Click the **[Subscribe](/support/my-favorites-icalendar/)** button at the top of the page for instructions on how to add your favorites to your calendar. There is also a button to download a CSV file of your favorites.
 
 ## The Kalahari
 
 ### The Kalahari is now cashless
 
-That's right, all restaurants and stands in the Kalahari are now cashless. The only types of payment they accept are credit cards and room wrist bands.
+That's right, all restaurants and stands in the Kalahari are now cashless. The only types of payment they accept are credit cards and room wristbands.
 
 ### 10% Discount at many restaurants
 
-The Kalahari provide the "Tree People" a 10% discount at many of the restaurants in the Kalahari. You'll need to show them your badge for the discount. We recommend you ask prior to ordering to ensure the particular restaurant you're at provides this discount.
+The Kalahari provides the "Tree People" a 10% discount at many of the restaurants in the Kalahari. You'll need to show them your badge for the discount. We recommend you ask before ordering to ensure the particular restaurant you're at provides this discount.
 
 ## Mess Hall
 
-The Mess Hall is our main gathering place. This is where you'll find conference-provided meals, keynotes and special events like THAT Wildlife.
+The Mess Hall is our main gathering place. This is where you'll find conference-provided meals, keynotes and special activities like THAT Wildlife. Oh and of course bacon 🥓!
 
 ## Open Spaces
 
 ### What is Open Spaces
 
-Interested in discussing a topic or sharing an experience with peers? Want to customize the conference to better fit your needs? You can! Part of THAT Conference includes over 10,000 SqFt of moderated Open Spaces and Maker environment that is available throughout the conference. This is the ideal place to make THAT Conference truly unique and interactive. Every year our attendees add more than 100 new sessions, talks, and hands-on learning to our schedule.
+Interested in discussing a topic or sharing an experience with peers? Want to customize the conference to better fit your needs? You can! Part of THAT Conference includes over 10,000 SqFt of moderated Open Spaces and a Maker environment that is available throughout the conference. This is the ideal place to make THAT Conference truly unique and interactive. Every year our attendees add more than 100 new sessions, talks, and hands-on learning to our schedule.
 
 ### Open Spaces Kick-Off
 
 After lunch on Tuesday around 12:00 will be the Open Spaces kick-off where we'll explain how Open Spaces works and start getting items on the Open Space's boards. we can't wait to see what you add to THAT Conference.
+
+## Sponsors and Data Collection
+
+We thank every one of our partners and sponsors, across all levels, for their amazing and continued support! Please take a few minutes to learn about our partners and stop by their booths, say hi, and engage in some interesting conversations.
+
+### Sharing with the Sponsors
+
+When you check into THAT Conference, we assigned you a four-digit PIN. We're using your four-digit PIN to share your information with our sponsors. The exchange is two-way, not only does the sponsor get your [shared profile](/my/profiles/shared/) information, you'll also receive information about who you spoke with.
+
+### Controlling what is shared (Shared Profile)
+
+To verify and update what information is being shared, head to your profile's [shared profile](/my/profiles/shared/) page. See all profile-related links by clicking on your profile picture in the upper right. Here you'll see exactly what is being shared with sponsors and update that data as needed. For example, say you used a personal email address to sign-up for THAT, but would rather share your professional email address. This is where you can update that.
+
+### Profile
+
+Your profile can be made public or private. Public profiles will show under our [members]('/members/') page and be picked up by search engines. Private profiles are not shown or discoverable by search engines. All counselors must have a public profile.
+
+## Dealing with Uncomfortable Situations
+
+At our core THAT Conference facilitates a safe space for everyone to interact and we will do whatever we believe is necessary to ensure that THAT Conference campers, camp Counselors, and guests will have a fun, safe and productive environment.
+
+### What to do about an Uncomfortable Situation
+
+To start, walk away. Remove yourself from the situation. Find any person with a **THAT CREW** shirt on, or head to the **Ranger Station** in the main hall to report the incident. We will take the appropriate action based on the situation and will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
 
  </div>
 </div>

--- a/src/routes/support/that-field-guide/+page.md
+++ b/src/routes/support/that-field-guide/+page.md
@@ -63,7 +63,11 @@ The Kalahari provides the "Tree People" a 10% discount at many of the restaurant
 
 ## Mess Hall
 
-The Mess Hall is our main gathering place. This is where you'll find conference-provided meals, keynotes and special activities like THAT Wildlife. Oh and of course bacon 🥓!
+The Mess Hall is our main gathering place. This is where you'll find conference-provided meals, keynotes and special activities like THAT Wildlife. Oh and of course bacon 🥓! All family and attendees are welcome in the Mess Hall during meal times. You must have a food wristband to get food from the food buffet lines.
+
+### Dietary Restrictions
+
+We've worked with the Kalahari to accommodate as many dietary restrictions as we can. Food line items are marked with dietary information like gluten-free, vegetarian, etc. Should you find yourself in need of assistance, please find a THAT Crew member. We'll be happy to assist!
 
 ## Open Spaces
 

--- a/src/routes/support/that-field-guide/+page.md
+++ b/src/routes/support/that-field-guide/+page.md
@@ -1,0 +1,69 @@
+---
+title: THAT Field Guide
+description: Camp field guide to help you find your way
+layout: support
+---
+
+<div class="max-w-prose mx-auto">
+  <div class="prose prose-lg text-gray-500">
+
+## Welcome
+
+Welcome to THAT Conference, we're so glad you're here. This Handbook should have the answers you need to successfully navigate the rapids leading up to and right on through the big event. Even if you've been to THAT Conference before, things may have changed. This Field Guide is your best source for up-to-date guides on what to do and where to go. Check back periodically for updates as well, as we'll be answering Frequently Asked Questions as they come up.
+
+Last updated on **June 8th, 2023**
+
+## Registration
+
+When you arrive at camp stop down at the Registration Desk and check-in. This is where you'll get your badge and swag. The Registration Desk remains open through the day to answer questions. There is also a lost and found.
+
+### Hugs, Handshakes, and Waves
+
+In these special times not everyone may be comfortable with handshakes or hugs, so to help remove the uneasiness of it we've come up with a simple system using **lanyard colors** ❤️ 💛 💚
+
+- **Red lanyard** indicates the person prefers no physical contact, aka. waves.
+- **Yellow lanyard** indicates the person limited contact and a handshake is okay.
+- **Green lanyard** indicates the person is okay with personal contact and a hug is acceptable.
+
+### THAT Ranger Station
+
+By Tuesday afternoon, once most people are checked in the registration Desk turns into THAT Ranger Station where a staff member will be available during all session hours. Sometimes we may even be able to answer your questions. You'll also find the **Lost and Found** at THAT Ranger Station.
+
+## Schedule and Favorites
+
+### Schedule
+
+With over 100 sessions, activities and Open Spaces sessions, keeping track of it all can be quite challenging. All regular sessions and event activities are listed in the schedule [here](/activities/). All the Open Spaces sessions are managed on the Open Spaces boards located in the Mess Hall.
+
+### Favorites
+
+By clicking on the ❤️ heart on a session, it adds this session to your [favorites](/my/favorites/). Favoriting sessions helps in may ways. You'll receive an email notifications whenever there is a change to session room or time. It also allows us how interested people are in a session to ensure there is a large enough room allocated.
+
+You can view a list of all of your favorites at [https://that.us/my/favorites](/my/favorites/). Click the **[Subscribe](/support/my-favorites-icalendar/)** button at the top of the page for instructions on how to add your favorites to your calendar.
+
+## The Kalahari
+
+### The Kalahari is now cashless
+
+That's right, all restaurants and stands in the Kalahari are now cashless. The only types of payment they accept are credit cards and room wrist bands.
+
+### 10% Discount at many restaurants
+
+The Kalahari provide the "Tree People" a 10% discount at many of the restaurants in the Kalahari. You'll need to show them your badge for the discount. We recommend you ask prior to ordering to ensure the particular restaurant you're at provides this discount.
+
+## Mess Hall
+
+The Mess Hall is our main gathering place. This is where you'll find conference-provided meals, keynotes and special events like THAT Wildlife.
+
+## Open Spaces
+
+### What is Open Spaces
+
+Interested in discussing a topic or sharing an experience with peers? Want to customize the conference to better fit your needs? You can! Part of THAT Conference includes over 10,000 SqFt of moderated Open Spaces and Maker environment that is available throughout the conference. This is the ideal place to make THAT Conference truly unique and interactive. Every year our attendees add more than 100 new sessions, talks, and hands-on learning to our schedule.
+
+### Open Spaces Kick-Off
+
+After lunch on Tuesday around 12:00 will be the Open Spaces kick-off where we'll explain how Open Spaces works and start getting items on the Open Space's boards. we can't wait to see what you add to THAT Conference.
+
+ </div>
+</div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,6 +1,6 @@
 /* eslint-disable global-require */
 module.exports = {
-	content: ['./src/**/*.{html,js,svelte,ts}'],
+	content: ['./src/**/*.{html,js,svelte,ts,md}'],
 	theme: {
 		extend: {
 			colors: {


### PR DESCRIPTION
## v3.7.0
THAT Field Guide added
fix: redo missing ® updates
Session Layout improvements
- Regular and Keynote sessions display dynamic length based on their `durationInMinutes` value
- Sessions w/ `primaryCategory` **THAT** and `type` **REGULAR** show as `A THAT Conference Activity`

Add return policy modal to checkout process
refactor markdown rendering
Add three month out blog post
