### PR TITLE
Ensures instance of error is passed to sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.11.9",
+	"version": "3.11.10",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",

--- a/src/_dataSources/api.that.tech/utilities/error.js
+++ b/src/_dataSources/api.that.tech/utilities/error.js
@@ -11,7 +11,14 @@ export const log = ({ errors, extra, tag }) => {
 			extra
 		});
 
-		Sentry.captureException(err);
+		let error;
+		if (err instanceof Error) {
+			error = err;
+		} else {
+			error = new Error(err.message ?? 'unknown error');
+		}
+
+		Sentry.captureException(error);
 	});
 };
 


### PR DESCRIPTION
## v3.11.10

Ensures instance of error is passed to sentry. Corrects the errors in Sentry: `Object captured as exception with keys: extensions, message, path`

Errors passed from GraphQL are not an instance of error which is causing an exception in Sentry when using `captureException`. This corrects that by checking first. 
True, for errors which are being created here don't have a stack trace, but they didn't to start with as it was on an object from GraphQL to begin with. 
The details of the error are still written to Sentry context.
