### PR TITLE
refactor: fetch retry to only create one sentry event per retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.11.10",
+	"version": "3.11.11",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",

--- a/src/_utils/gfetch.js
+++ b/src/_utils/gfetch.js
@@ -28,12 +28,12 @@ function init(fetch) {
 
 	function retryOn(attempt, error, response) {
 		if (error !== null || response?.status === 503) {
-			Sentry.captureException(error);
-			Sentry.captureMessage(
-				`Fetch network error, retrying, attempt number ${attempt + 1}, response.status ${
+			Sentry.setContext('fetch retryOn', {
+				message: `Fetch network error, retrying, attempt number ${attempt + 1}, response.status ${
 					response?.status
-				}`
-			);
+				}, is response empty? ${response === undefined || response === null}`
+			});
+			Sentry.captureException(error);
 
 			return true;
 		}


### PR DESCRIPTION
## v3.11.11

On each fetch retry 2 events were added to Sentry. One on the `captureException` and a second on `captureMessage`. This refactor moves the captureMessage information into context of the exception event. The goal is to make the Sentry events more meaningful and less noisy. 