### PR TITLE
fix: open space sessions no longer showing in session/activities list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.11.19",
+	"version": "3.11.20",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",

--- a/src/_components/activities/List.svelte
+++ b/src/_components/activities/List.svelte
@@ -88,7 +88,8 @@
 	$: primaryCategorySort = activitiesFiltered.filter(
 		(activity) =>
 			(activity.category == 'FAMILY' ? family : false) ||
-			(activity.category == 'PROFESSIONAL' ? professional : false)
+			(activity.category == 'PROFESSIONAL' ? professional : false) ||
+			activities.category == null
 	);
 
 	$: activitiesLocationCategoryFiltered = primaryCategorySort.filter(


### PR DESCRIPTION
## v3.11.20

fix issue with /activities where `OPEN_SPACE` type session no longer displayed. 