### PR TITLE
Promote next/feature to production

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.13.3",
+	"version": "3.13.4",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",

--- a/src/_utils/config.public.js
+++ b/src/_utils/config.public.js
@@ -1,4 +1,5 @@
 import { env } from '$env/dynamic/public';
+import { version } from '$app/environment';
 
 function configMissing(configKey) {
 	const message = `Missing required public environment varable: ${configKey}`;
@@ -7,8 +8,8 @@ function configMissing(configKey) {
 
 export default {
 	hostURL: env.PUBLIC_HOST_URL || 'https://that.us',
-	nodeEnv: env.NODE_ENV,
-	version: '3.2.1',
+	nodeEnv: env.PUBLIC_VERCEL_ENV,
+	version: version ?? '0.0.0.0',
 	eventId: 'YWavA70szR8rxSwrLJaL',
 	eventSlug: 'thatus/daily',
 	api: {
@@ -47,7 +48,7 @@ export const securityConfig = () => {
 
 export const logging = {
 	dsn: 'https://15d4b436dc0a4366a0ac388c65772926@o235190.ingest.sentry.io/5357492',
-	environment: env.NODE_ENV
+	environment: env.PUBLIC_VERCEL_ENV
 };
 
 export const debug = {

--- a/src/hooks.client.js
+++ b/src/hooks.client.js
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/sveltekit';
+import { env } from '$env/dynamic/public';
 
 // If you don't want to use Session Replay, remove the `Replay` integration,
 // `replaysSessionSampleRate` and `replaysOnErrorSampleRate` options.
@@ -7,7 +8,8 @@ Sentry.init({
 	tracesSampleRate: 1,
 	replaysSessionSampleRate: 0.1,
 	replaysOnErrorSampleRate: 1,
-	integrations: [new Sentry.Replay()]
+	integrations: [new Sentry.Replay()],
+	environment: env.PUBLIC_VERCEL_ENV
 });
 
 export const handleError = Sentry.handleErrorWithSentry();

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,9 +1,11 @@
 import { sequence } from '@sveltejs/kit/hooks';
 import * as Sentry from '@sentry/sveltekit';
+import { env } from '$env/dynamic/public';
 
 Sentry.init({
 	dsn: 'https://15d4b436dc0a4366a0ac388c65772926@o235190.ingest.sentry.io/5357492',
-	tracesSampleRate: 1
+	tracesSampleRate: 1,
+	environment: env.PUBLIC_VERCEL_ENV
 });
 
 export const handleError = Sentry.handleErrorWithSentry();


### PR DESCRIPTION
## v3.13.4

refactor: use of NODE_ENV which is not exposed by Sveltekit