### PR TITLE
fix: edit activity not found or no permissions to it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.13.5",
+	"version": "3.13.6",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",

--- a/src/routes/activities/edit/+layout.js
+++ b/src/routes/activities/edit/+layout.js
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore.js';
 import isBetween from 'dayjs/plugin/isBetween.js';
 import lodash from 'lodash';
+import { error } from '@sveltejs/kit';
 
 import eventsApi from '$dataSources/api.that.tech/events/queries';
 import sessionsQueryApi from '$dataSources/api.that.tech/sessions/queries';
@@ -46,6 +47,12 @@ export const load = auth0.withPageAuthRequired({
 			queryMySessionById(activityId),
 			queryEventsByCommunity()
 		]);
+
+		if (!activityDetails) {
+			throw new error(404, {
+				message: 'Activity Not Found'
+			});
+		}
 
 		return {
 			activityDetails,


### PR DESCRIPTION
## v3.13.6

- fix 500 error when editing session which doesn't exist or you don't have access to. Returning 404.