### PR TITLE
Refactor order success page

### DIFF
--- a/.github/workflows/release-success.yml
+++ b/.github/workflows/release-success.yml
@@ -12,9 +12,6 @@ jobs:
       - name: Ping Google
         run: |
           curl https://www.google.com/ping?sitemap=https://that.us/sitemap.xml
-      - name: Ping Bing
-        run: |
-          curl https://www.bing.com/ping?sitemap=https://that.us/sitemap.xml
       - name: Purge CloudFlare
         run: |
           curl -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_THATUS_ID }}/purge_cache" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_PURGE_TOKEN }}" -H "Content-Type:application/json" --data '{"purge_everything":true}'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.13.6",
+	"version": "3.13.7",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",

--- a/src/_elements/links/Standard.svelte
+++ b/src/_elements/links/Standard.svelte
@@ -1,11 +1,13 @@
 <script>
 	export let href;
 	export let rel;
+	export let target;
 </script>
 
 <a
 	{href}
 	{rel}
+	{target}
 	class="cursor-pointer rounded-md border-2 border-thatBlue-500 bg-white px-8 py-3 text-base
     font-medium leading-6 text-thatBlue-500 shadow
     transition duration-150 ease-in-out hover:bg-thatBlue-500

--- a/src/routes/orders/_components/_Cart.svelte
+++ b/src/routes/orders/_components/_Cart.svelte
@@ -188,7 +188,7 @@
 		{#if activateRefundPolicyModal === true}
 			<ActionModal
 				title="Refund Policy"
-				text="Ticket refunds will not be issued on any ticket <span class='font-bold'>30 days</span> before the event or thereafter. Prior to that, a $30.00 (per ticket) processing fee will be applied to each attendee ticket refund and a $10.00 (per ticket) processing fee will be applied to each family ticket refund. Memberships are non-refundable.">
+				text="Ticket refunds will not be issued on any ticket <span class='font-bold'>30 days</span> before the event or thereafter. Prior to that, a $30.00 (per ticket) processing fee will be applied to each Camper ticket refund and a $10.00 (per ticket) processing fee will be applied to each Geekling and Campmate ticket refund. Memberships are non-refundable.">
 				<div class="flex justify-center space-x-6">
 					<StandardButton on:click={() => openRefundPolicyModal(false)}>Cancel</StandardButton>
 					<StandardButton on:click={handleCheckout}>Agree and Continue</StandardButton>

--- a/src/routes/orders/success/+page.svelte
+++ b/src/routes/orders/success/+page.svelte
@@ -35,9 +35,11 @@
 	const eventLocation = $page.url.searchParams.has('EL')
 		? $page.url.searchParams.get('EL')
 		: undefined;
-	const targetLocations = $page.url.searchParams.has('TL')
-		? $page.url.searchParams.getAll('TL')
-		: [];
+	let targetLocations = [];
+	if ($page.url.searchParams.has('TL')) {
+		targetLocations = $page.url.searchParams.getAll('TL');
+		targetLocations = targetLocations.map((tl) => tl.toUpperCase());
+	}
 </script>
 
 <Seo title={metaTags.title} tags={metaTags.tags} />
@@ -69,83 +71,122 @@
 					>If you do not see those, please check your junk/spam folders, as sometimes we manage to
 					land there accidentally.</span>
 				At any time you can view your
-				<a class="hover" href="/my/settings/order-history/">order history</a> and reprint your receipt.
+				<a class="hover" href="/my/settings/order-history/" target="_blank">order history</a> and reprint
+				your receipt.
 			</p>
 
 			<div class="my-8 flex justify-center md:justify-end">
-				<StandardLink href="/my/settings/order-history/">View Your Order History</StandardLink>
+				<StandardLink href="/my/settings/order-history/" target="_blank"
+					>View Your Order History</StandardLink>
 			</div>
 
-			<h3>Next steps</h3>
-			<p>Based on your purchase we have a few follow up things for you.</p>
+			{#if eventLocation && targetLocations.length > 0}
+				<h3>Next steps</h3>
+				<p>Based on your purchase we have some follow-ups for you.</p>
+				<h4>You're going to THAT Conference!</h4>
 
-			{#if eventLocation}
-				{#if targetLocations.length > 0}
-					<h4>You have event tickets!!!</h4>
-
-					{#if targetLocations.includes('AT')}
-						<p>
-							First things first, let's get your travel and rooms sorted. Just head over to our
-							travel page for room blocks, addresses, and other details.
-						</p>
-
-						<div class="my-8 flex justify-center md:justify-end">
-							{#if eventLocation.toUpperCase() === 'WI'}
-								<StandardLink href="/support/travel/wi/"
-									>Book Your Travel To Wisconsin</StandardLink>
-							{/if}
-							{#if eventLocation.toUpperCase() === 'TX'}
-								<StandardLink href="/support/travel/tx/">Book Your Travel To Texas</StandardLink>
-							{/if}
-						</div>
-
-						<p>
-							Soon we will also send you an email asking for your dietary restrictions, shirt sizes,
-							and a few other items.
-						</p>
-					{/if}
-
-					{#if targetLocations.includes('ON')}
-						<p>
-							No further action is required for your <span class="font-extrabold">ON THAT</span> tickets.
-							Ok, small lie there. You now have access to that event and are free to start adding to
-							the schedule. That's correct; you can add sessions as well, and make sure to select the
-							right event.
-						</p>
-
-						<div class="my-8 flex justify-center md:justify-end">
-							<StandardLink href="/activities/create/">Create an Activity</StandardLink>
-						</div>
-					{/if}
-				{/if}
-			{/if}
-
-			{#if isBulkPurchase}
-				<h4>Action Required - You have unallocated tickets.</h4>
-				<p>
-					You've purchased multiple tickets, and some or all of those tickets now need to be
-					allocated to someone. To gain access, that someone has to have a valid account on THAT.us.
-					You need that user's email address to assign the ticket. Once assigned, THAT.us will
-					contact them and take care of the rest.
-				</p>
 				{#if targetLocations.includes('AT')}
 					<p>
-						If one of those tickets is for a spouse or child, they do not need to be allocated, but
-						you will need to answer the follow-up questions on their behalf.
+						Time to get your travel and hotel rooms sorted. Head over to our travel page for hotel
+						room blocks, addresses, and other details.
+					</p>
+
+					<div class="my-8 flex justify-center md:justify-end">
+						{#if eventLocation.toUpperCase() === 'WI'}
+							<StandardLink href="/support/travel/wi/" target="_blank"
+								>Book Your Travel To Wisconsin</StandardLink>
+						{/if}
+						{#if eventLocation.toUpperCase() === 'TX'}
+							<StandardLink href="/support/travel/tx/" target="_blank"
+								>Book Your Travel To Texas</StandardLink>
+						{/if}
+					</div>
+
+					<h4>Dietary Requirements and T-Shirts</h4>
+					<p>
+						Do you have dietary requirements? THAT Conference works with the Kalahari catering team
+						to provide meals that encompass a variety of dietary choices. At every meal, we strive
+						to provide gluten-free, vegetarian and vegan options. Menus are posted daily and labels
+						are displayed next to each food item to help you make the best decision based on your
+						needs. If you have a severe dietary requirement, please email us at <a
+							href="mailto:hello@that.us"
+							target="_blank"
+							class="hover">hello@that.us</a> so we can work together in finding the right solution to
+						fit your needs.
+					</p>
+					<p>
+						All Camper, Campmate and Geekling tickets include an official THAT t-shirt. During
+						on-site registration, you can choose your desired shirt size. We order a wide range of
+						sizes for each event. If for some reason, we run out of the size you’d like, we’ll send
+						you one after the event!
 					</p>
 				{/if}
 
-				<div class="my-8 flex justify-center md:justify-end">
-					<StandardLink href="/my/settings/order-history/">Allocate Tickets</StandardLink>
-				</div>
-			{/if}
+				{#if targetLocations.includes('ON')}
+					<p>
+						No further action is required for your <span class="font-extrabold">ON THAT</span> tickets.
+						Ok, small lie there. You now have access to that event and are free to start adding to the
+						schedule. That's correct; you can add sessions as well, and make sure to select the right
+						event.
+					</p>
 
-			{#if isMembership}
-				<h4>Thank you purchasing an annual membership.</h4>
+					<div class="my-8 flex justify-center md:justify-end">
+						<StandardLink href="https://that.us/activities/create/" target="_blank"
+							>Create an Activity</StandardLink>
+					</div>
+				{/if}
+				{#if isBulkPurchase}
+					<h4>Action Required – You have unallocated tickets</h4>
+					<p>
+						You've purchased multiple tickets, and those tickets need to be allocated (assigned) to
+						someone. The process is easy. All you need to transfer a ticket is the
+						<span class="font-bold">profile email address</span> of the person you are transferring
+						the ticket to. We've put together the steps
+						<a class="hover" href="/support/transfer-a-ticket/" target="_blank"
+							>in this handy guide</a>
+						for your reference.
+					</p>
+					<p>
+						Remember to allocate a ticket to <em>yourself</em> if <em>you're</em> attending!
+					</p>
+					{#if targetLocations.includes('AT')}
+						<p>If any of the tickets are for a spouse or child, they don't need to be allocated.</p>
+					{/if}
+
+					<div class="my-8 flex justify-center md:justify-end">
+						<StandardLink href="/my/settings/order-history/" target="_blank"
+							>Allocate Tickets Now</StandardLink>
+					</div>
+				{/if}
+
+				<h4>Ticket Refunds</h4>
+				<p>
+					Ticket refunds will not be issued on any ticket <span class="font-bold">30 days</span> before
+					the event or thereafter. Prior to that, a $30.00 (per ticket) processing fee will be applied
+					to each Camper ticket refund and a $10.00 (per ticket) processing fee will be applied to each
+					Geekling and Campmate ticket refund.
+				</p>
+
+				<h4>Meet THAT Camper</h4>
+				<p>
+					Say hello to Meet THAT Camper – your weekly chance to connect with a fellow geek before
+					THAT Conference. Every Monday at 9 AM central, we'll introduce you to another attendee
+					headed to the event. Getting started is easy, go to your
+					<a class="hover" href="/my/notification-preferences/" target="_blank"
+						>notification preferences</a> and enable the Meet THAT Camper notification. It's that simple,
+					and you can shut it off at any time. There are more details about Meet THAT Camper on the notification
+					preferences page.
+				</p>
+				<div class="my-8 flex justify-center md:justify-end">
+					<StandardLink href="/my/notification-preferences/" target="_blank"
+						>Meet THAT Camper</StandardLink>
+				</div>
+			{:else if isMembership}
+				<h3>Thank you for purchasing an annual membership</h3>
 				<p>
 					We're grateful to have you as an annual member. Your membership helps us run the daily
 					operations while also having direct input into how things evolve. You will soon see
-					another email with a signup link to our private discord server.
+					another email with a signup link to our member's private discord server.
 				</p>
 				<p>Once again, Thank You!</p>
 			{/if}
@@ -157,24 +198,28 @@
 			</p>
 			<ul>
 				<li>
-					<a class="hover" href="/my/profiles/slack">Join us in Slack.</a>
+					Join us in <a class="hover" href="/my/profiles/slack/" target="_blank">THAT Slack</a> and
+					<a class="hover" href="https://that.community" target="_blank"> THAT Discord</a>
 				</li>
 				<li>
 					Get involved on THAT.us! Better yet, create an activity.
-					<a class="hover" href="/support/">Learn how to get started.</a>
+					<a class="hover" href="/support/" target="_blank">Learn how to get started.</a>
 				</li>
 				<li>
-					Stay up to date. <a class="hover" href="/support/staying-up-to-date/"
-						>Subscribe to the calendar.</a>
+					<a class="hover" href="/support/staying-up-to-date/" target="_blank">Stay up to date</a>.
 				</li>
 				<li>
-					Get ready for what's coming. Did you know we have an event every month?
-					<a class="hover" href="/events/">Check out our past and upcoming events.</a>
+					❤️ your favorite sessions to receive emails on session updates, see them in your
+					<a class="hover" href="/my/favorites/" target="_blank">favorites feed</a>
+					and add them to
+					<a class="hover" href="/support/my-favorites-icalendar/" target="_blank"
+						>your own calendar</a
+					>.
 				</li>
 				<li>Signup for our newsletter!</li>
 			</ul>
 
-			<h3>Lastly, we’re here to help.</h3>
+			<h3>Lastly, we're here to help</h3>
 			<p>
 				We're here to support you and the community. Anything we can do to improve, or if you wish
 				there was a particular feature, please tell us. Our entire platform is open source, and
@@ -194,7 +239,7 @@
 	</div>
 </div>
 
-<style>
+<style lang="postcss">
 	.hover:hover {
 		@apply text-thatOrange-400;
 		@apply underline;

--- a/src/routes/orders/success/claim-ticket/+page.svelte
+++ b/src/routes/orders/success/claim-ticket/+page.svelte
@@ -48,9 +48,9 @@
 			When you get to the event make sure you check in at registration to get your sponsor badge.
 		</li>
 		<li>
-			On <strong>Monday at 1:00 PM</strong> there will be a sponsor meeting in the Open Spaces area.
-			This is an opportunity to meet one another, discuss the event, answer any questions, and get things
-			kicked off before the early registration meet and greet that evening.
+			On <span class="font-bold">Monday at 1:00 PM</span> there will be a sponsor meeting in the Open
+			Spaces area. This is an opportunity to meet one another, discuss the event, answer any questions,
+			and get things kicked off before the early registration meet and greet that evening.
 		</li>
 	</ol>
 

--- a/src/routes/support/transfer-a-ticket/+page.svelte
+++ b/src/routes/support/transfer-a-ticket/+page.svelte
@@ -53,8 +53,11 @@
 			<p>
 				Transferring is easy, just enter a valid THAT.us account profile email address and click
 				transfer. The page will inform you if the email address is not found. Check with the person
-				you are transferring the ticket to for the email address they're using in their profile (<strong
-					>Note:</strong> Their profile email address may be different than their login email address)
+				you are transferring the ticket to for the email address they're using in their profile.
+			</p>
+			<p>
+				(<span class="font-bold">Note:</span> Their profile email address may be different than their
+				login email address)
 			</p>
 
 			<div class="transform text-center">
@@ -80,7 +83,7 @@
 
 			<h2>Family Tickets</h2>
 			<p>
-				All family tickets (Campmate, Geekling, etc.) also need to be assigned to someone. If the
+				All family tickets (Campmate, Geekling, etc.) also should be assigned to someone. If the
 				family member isn't old enough to have a THAT account or doesn't wish to have one, then
 				simply assign the family ticket to the Camper they are coming with.
 			</p>


### PR DESCRIPTION
## v3.13.7

- refactor order success page to improve message and add latest THAT offerings
- Remove bing update ping from `release-success` as it's no longer supported by bing
- Refactor dateless ticket refund statement

follows changes made in thatconference/thatconference.com#89 

### Testing

- success page on ticket purchase: `/orders/success?EL=tx&M=0&B=0&TL=at`
- success page on ticket purchase w/ bulk: `/orders/success?EL=tx&M=0&B=4&TL=at`
- success page on membership purchase: `/orders/success?EL=tx&M=1&B=0` or `/orders/success?EL=thatus&M=1&B=0`
