### PR TITLE
In-person redirect to thatconference.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.13.8",
+	"version": "3.14.0",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",

--- a/src/_utils/config.public.js
+++ b/src/_utils/config.public.js
@@ -124,3 +124,8 @@ export const kalahari = {
 		}
 	}
 };
+
+export const thatConferenceRedirect = {
+	baseUrl: `https://thatconference.com`,
+	defaultStatus: 308
+};

--- a/src/routes/call-for-counselors/+page.js
+++ b/src/routes/call-for-counselors/+page.js
@@ -1,5 +1,6 @@
 import { redirect } from '@sveltejs/kit';
+import { thatConferenceRedirect as tcr } from '$utils/config.public.js';
 
 export async function load() {
-	throw redirect(301, `https://thatconference.com/cfp`);
+	throw redirect(301, `${tcr.baseUrl}/cfp`);
 }

--- a/src/routes/cfp/+page.js
+++ b/src/routes/cfp/+page.js
@@ -1,5 +1,6 @@
 import { redirect } from '@sveltejs/kit';
+import { thatConferenceRedirect as tcr } from '$utils/config.public.js';
 
 export async function load() {
-	throw redirect(301, `https://thatconference.com/cfp`);
+	throw redirect(301, `${tcr.baseUrl}/cfp`);
 }

--- a/src/routes/events/(online)/[event]/[date]/+layout.js
+++ b/src/routes/events/(online)/[event]/[date]/+layout.js
@@ -1,3 +1,4 @@
+import { error } from '@sveltejs/kit';
 import eventsApi from '$dataSources/api.that.tech/events/queries';
 
 export async function load({ params, fetch }) {
@@ -5,9 +6,13 @@ export async function load({ params, fetch }) {
 	const eventSlug = `${event}/${date}`;
 
 	const { queryEventWithSpeakersBySlug } = eventsApi(fetch);
+	const fetchedEvent = await queryEventWithSpeakersBySlug(eventSlug);
+	if (!fetchedEvent) {
+		throw error(404, 'Event not found');
+	}
 
 	return {
 		eventSlug,
-		event: await queryEventWithSpeakersBySlug(eventSlug)
+		event: fetchedEvent
 	};
 }

--- a/src/routes/events/(thatConferences)/tx/+page.js
+++ b/src/routes/events/(thatConferences)/tx/+page.js
@@ -1,6 +1,6 @@
 import { redirect } from '@sveltejs/kit';
 import { thatConferenceRedirect as tcr } from '$utils/config.public.js';
 
-export async function load() {
-	throw redirect(301, `${tcr.baseUrl}/`);
+export function load() {
+	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/tx`);
 }

--- a/src/routes/events/(thatConferences)/tx/[year]/+page.js
+++ b/src/routes/events/(thatConferences)/tx/[year]/+page.js
@@ -6,5 +6,5 @@ export function load({ params }) {
 	if (!Number.isInteger(Number.parseInt(year, 10))) {
 		throw error(404, 'Event not found');
 	}
-	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/tx/${year}/travel/`);
+	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/tx/${year}/`);
 }

--- a/src/routes/events/(thatConferences)/tx/[year]/schedule/+page.js
+++ b/src/routes/events/(thatConferences)/tx/[year]/schedule/+page.js
@@ -1,12 +1,20 @@
-import sessionsApi from '$dataSources/api.that.tech/sessions';
+// import sessionsApi from '$dataSources/api.that.tech/sessions';
+import { redirect, error } from '@sveltejs/kit';
+import { thatConferenceRedirect as tcr } from '$utils/config.public.js';
 
-export async function load({ parent }) {
-	const { querySessionsBySlug } = sessionsApi();
+export function load({ params }) {
+	const { year } = params;
+	if (!Number.isInteger(Number.parseInt(year, 10))) {
+		throw error(404, 'Event not found');
+	}
+	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/tx/${year}/schedule/`);
 
-	let { event } = await parent();
-	const sessions = await querySessionsBySlug({ slug: event.slug, pageSize: 250 });
+	// const { querySessionsBySlug } = sessionsApi();
 
-	return {
-		sessions
-	};
+	// let { event } = await parent();
+	// const sessions = await querySessionsBySlug({ slug: event.slug, pageSize: 250 });
+
+	// return {
+	// 	sessions
+	// };
 }

--- a/src/routes/events/(thatConferences)/tx/[year]/sponsors/+page.js
+++ b/src/routes/events/(thatConferences)/tx/[year]/sponsors/+page.js
@@ -1,18 +1,26 @@
-import lodash from 'lodash';
-import partnerQueryApi from '$dataSources/api.that.tech/partner/queries';
+// import lodash from 'lodash';
+// import partnerQueryApi from '$dataSources/api.that.tech/partner/queries';
+import { redirect, error } from '@sveltejs/kit';
+import { thatConferenceRedirect as tcr } from '$utils/config.public.js';
 
-export async function load({ params, fetch }) {
-	const { groupBy } = lodash;
+export function load({ params }) {
 	const { year } = params;
-	const { getEventPartners } = partnerQueryApi(fetch);
+	if (!Number.isInteger(Number.parseInt(year, 10))) {
+		throw error(404, 'Event not found');
+	}
+	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/tx/${year}/sponsors/`);
 
-	const eventSlug = `tx/${year}`;
+	// const { groupBy } = lodash;
+	// const { year } = params;
+	// const { getEventPartners } = partnerQueryApi(fetch);
 
-	const event = await getEventPartners(eventSlug);
-	const levels = groupBy(event.partners, 'level');
+	// const eventSlug = `tx/${year}`;
 
-	return {
-		event,
-		levels
-	};
+	// const event = await getEventPartners(eventSlug);
+	// const levels = groupBy(event.partners, 'level');
+
+	// return {
+	// 	event,
+	// 	levels
+	// };
 }

--- a/src/routes/events/(thatConferences)/tx/[year]/tickets/+page.js
+++ b/src/routes/events/(thatConferences)/tx/[year]/tickets/+page.js
@@ -6,5 +6,5 @@ export function load({ params }) {
 	if (!Number.isInteger(Number.parseInt(year, 10))) {
 		throw error(404, 'Event not found');
 	}
-	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/tx/${year}/travel/`);
+	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/tx/${year}/tickets/`);
 }

--- a/src/routes/events/(thatConferences)/wi/+page.js
+++ b/src/routes/events/(thatConferences)/wi/+page.js
@@ -1,6 +1,6 @@
 import { redirect } from '@sveltejs/kit';
 import { thatConferenceRedirect as tcr } from '$utils/config.public.js';
 
-export async function load() {
-	throw redirect(301, `${tcr.baseUrl}/`);
+export function load() {
+	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/wi/`);
 }

--- a/src/routes/events/(thatConferences)/wi/[year]/+page.js
+++ b/src/routes/events/(thatConferences)/wi/[year]/+page.js
@@ -6,5 +6,5 @@ export function load({ params }) {
 	if (!Number.isInteger(Number.parseInt(year, 10))) {
 		throw error(404, 'Event not found');
 	}
-	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/tx/${year}/travel/`);
+	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/wi/${year}/`);
 }

--- a/src/routes/events/(thatConferences)/wi/[year]/schedule/+page.js
+++ b/src/routes/events/(thatConferences)/wi/[year]/schedule/+page.js
@@ -1,15 +1,23 @@
-import sessionsApi from '$dataSources/api.that.tech/sessions';
+import { redirect, error } from '@sveltejs/kit';
+import { thatConferenceRedirect as tcr } from '$utils/config.public.js';
+// import sessionsApi from '$dataSources/api.that.tech/sessions';
 
-export async function load({ parent, url }) {
-	const { querySessionsBySlug } = sessionsApi();
+export async function load({ params }) {
+	const { year } = params;
+	if (!Number.isInteger(Number.parseInt(year, 10))) {
+		throw error(404, 'Event not found');
+	}
+	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/wi/${year}/schedule/`);
 
-	let filterForFamily = url.searchParams.get('family') === 'true';
+	// const { querySessionsBySlug } = sessionsApi();
 
-	let { event } = await parent();
-	const sessions = await querySessionsBySlug({ slug: event.slug, pageSize: 250 });
+	// let filterForFamily = url.searchParams.get('family') === 'true';
 
-	return {
-		sessions,
-		filterForFamily
-	};
+	// let { event } = await parent();
+	// const sessions = await querySessionsBySlug({ slug: event.slug, pageSize: 250 });
+
+	// return {
+	// 	sessions,
+	// 	filterForFamily
+	// };
 }

--- a/src/routes/events/(thatConferences)/wi/[year]/sponsors/+page.js
+++ b/src/routes/events/(thatConferences)/wi/[year]/sponsors/+page.js
@@ -1,18 +1,26 @@
-import lodash from 'lodash';
-import partnerQueryApi from '$dataSources/api.that.tech/partner/queries';
+// import lodash from 'lodash';
+// import partnerQueryApi from '$dataSources/api.that.tech/partner/queries';
+import { redirect, error } from '@sveltejs/kit';
+import { thatConferenceRedirect as tcr } from '$utils/config.public.js';
 
-export async function load({ params, fetch }) {
-	const { groupBy } = lodash;
+export async function load({ params }) {
 	const { year } = params;
-	const { getEventPartners } = partnerQueryApi(fetch);
+	if (!Number.isInteger(Number.parseInt(year, 10))) {
+		throw error(404, 'Event not found');
+	}
+	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/wi/${year}/sponsors/`);
 
-	const eventSlug = `wi/${year}`;
+	// const { groupBy } = lodash;
+	// const { year } = params;
+	// const { getEventPartners } = partnerQueryApi(fetch);
 
-	const event = await getEventPartners(eventSlug);
-	const levels = groupBy(event.partners, 'level');
+	// const eventSlug = `wi/${year}`;
 
-	return {
-		event,
-		levels
-	};
+	// const event = await getEventPartners(eventSlug);
+	// const levels = groupBy(event.partners, 'level');
+
+	// return {
+	// 	event,
+	// 	levels
+	// };
 }

--- a/src/routes/events/(thatConferences)/wi/[year]/tickets/+page.js
+++ b/src/routes/events/(thatConferences)/wi/[year]/tickets/+page.js
@@ -6,5 +6,5 @@ export function load({ params }) {
 	if (!Number.isInteger(Number.parseInt(year, 10))) {
 		throw error(404, 'Event not found');
 	}
-	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/tx/${year}/travel/`);
+	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/wi/${year}/tickets/`);
 }

--- a/src/routes/events/(thatConferences)/wi/[year]/travel/+page.js
+++ b/src/routes/events/(thatConferences)/wi/[year]/travel/+page.js
@@ -1,7 +1,10 @@
-import { redirect } from '@sveltejs/kit';
+import { redirect, error } from '@sveltejs/kit';
+import { thatConferenceRedirect as tcr } from '$utils/config.public.js';
 
-export async function load({ parent }) {
-	const { eventName } = await parent();
-
-	throw redirect(302, `/support/travel/${eventName}/`);
+export function load({ params }) {
+	const { year } = params;
+	if (!Number.isInteger(Number.parseInt(year, 10))) {
+		throw error(404, 'Event not found');
+	}
+	throw redirect(tcr.defaultStatus, `${tcr.baseUrl}/wi/${year}/travel/`);
 }

--- a/src/routes/family/+page.js
+++ b/src/routes/family/+page.js
@@ -1,5 +1,6 @@
 import { redirect } from '@sveltejs/kit';
+import { thatConferenceRedirect as tcr } from '$utils/config.public.js';
 
 export async function load() {
-	throw redirect(302, `/events/wi/2023/schedule/?family=true`);
+	throw redirect(301, `${tcr.baseUrl}/family`);
 }

--- a/src/routes/sponsorships/apply/+page.js
+++ b/src/routes/sponsorships/apply/+page.js
@@ -1,5 +1,6 @@
 import { redirect } from '@sveltejs/kit';
+import { thatConferenceRedirect as tcr } from '$utils/config.public.js';
 
 export async function load() {
-	throw redirect(301, `https://thatconference.com/sponsorships/apply`);
+	throw redirect(301, `${tcr.baseUrl}/sponsorships/apply`);
 }

--- a/src/routes/tx/+page.js
+++ b/src/routes/tx/+page.js
@@ -1,6 +1,6 @@
 import { redirect } from '@sveltejs/kit';
-import { events } from '$utils/config.public';
+import { thatConferenceRedirect as tcr } from '$utils/config.public.js';
 
 export async function load() {
-	throw redirect(301, `https://thatconference.com/${events.next.tx.slug}/`);
+	throw redirect(301, `${tcr.baseUrl}/tx`);
 }

--- a/src/routes/wi/+page.js
+++ b/src/routes/wi/+page.js
@@ -1,6 +1,6 @@
 import { redirect } from '@sveltejs/kit';
-import { events } from '$utils/config.public';
+import { thatConferenceRedirect as tcr } from '$utils/config.public.js';
 
 export async function load() {
-	throw redirect(301, `https://thatconference.com/${events.next.wi.slug}/`);
+	throw redirect(301, `${tcr.baseUrl}/wi`);
 }


### PR DESCRIPTION
## v3.14.0

- adds redirects for in-person routes to thatconference.com. Does not include sessions
- Redirect base url and default https status added to public config
- Fix unknown event error (500) in src/routes/events/(online)/[event]/[date]/+layout.js

### Updated routes
/events/tx/
/events/tx/2024/
/events/tx/2024/schedule/
/events/tx/2024/sponsors/
/events/tx/2024/tickets/
/events/tx/2024/travel/
/events/wi/
/events/wi/2024/
/events/wi/2024/schedule/
/events/wi/2024/sponsors/
/events/wi/2024/tickets/
/events/wi/2024/travel/
/tx
/wi
/family
/that-conference
/cfp
/call-for-counselors
/sponsorships/apply



### tests
- http://localhost:5173/events/tx/
- http://localhost:5173/events/tx/2024/
- http://localhost:5173/events/tx/2024/schedule/
- http://localhost:5173/events/tx/2024/sponsors/
- http://localhost:5173/events/tx/2024/tickets/
- http://localhost:5173/events/tx/2024/travel/
- http://localhost:5173/events/wi/
- http://localhost:5173/events/wi/2024/
- http://localhost:5173/events/wi/2024/schedule/
- http://localhost:5173/events/wi/2024/sponsors/
- http://localhost:5173/events/wi/2024/tickets/
- http://localhost:5173/events/wi/2024/travel/
- http://localhost:5173/tx
- http://localhost:5173/wi
- http://localhost:5173/family
- http://localhost:5173/that-conference
- http://localhost:5173/cfp
- http://localhost:5173/call-for-counselors
- http://localhost:5173/sponsorships/apply