### PR TITLE
fix: correctly show user isn't assigned to partner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.14.1",
+	"version": "3.14.2",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",

--- a/src/_dataSources/api.that.tech/partner/leads/mutations.js
+++ b/src/_dataSources/api.that.tech/partner/leads/mutations.js
@@ -49,8 +49,18 @@ export default (fetch) => {
 			let results;
 
 			if (data) {
-				const { add } = data.partners.us.leads;
-				results = add;
+				if (data.partners.us?.leads) {
+					const add = data.partners.us.leads;
+					results = add;
+				} else {
+					let message = 'There was an issue saving the lead';
+					if (errors) message = errors[0]?.message ?? message;
+
+					results = {
+						message,
+						result: false
+					};
+				}
 			}
 
 			return results;


### PR DESCRIPTION
## v3.14.2

Shows api response with issues when adding a lead. E.g. user not assigned to partner.