### PR TITLE
Feat/that join v2 copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.15.2",
+	"version": "3.16.0",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",

--- a/src/_components/activities/ActivityDetails.svelte
+++ b/src/_components/activities/ActivityDetails.svelte
@@ -37,6 +37,7 @@
 	// import CalendarButton from './elements/CalendarButton.svelte';
 	import { SocialLink } from '../social';
 	import Success from '../notifications/Success.svelte';
+	import DiscordLinksModal from './DiscordLinksModal.svelte';
 
 	dayjs.extend(isBetween);
 	dayjs.extend(isSameOrAfter);
@@ -66,7 +67,8 @@
 		takeaways,
 		agenda,
 		supportingArtifacts,
-		primaryCategory
+		primaryCategory,
+		discord
 	} = activity;
 
 	let dropDownKeyValuePairs = getContext('DROP_DOWN_KEY_VALUE_PAIRS');
@@ -179,6 +181,7 @@
 	}
 
 	const joinUrl = getSessionUrl();
+	let showDiscordLinksModal = false;
 </script>
 
 {#if isNew}
@@ -187,6 +190,9 @@
 	<Success title="Success 🎊" text="Successfully updated {title}." />
 {/if}
 
+{#if showDiscordLinksModal === true}
+	<DiscordLinksModal {discord} bind:showModal={showDiscordLinksModal} />
+{/if}
 <div>
 	<!--header-->
 	<div class="border-b border-gray-300 px-4 py-5 sm:px-6">
@@ -325,18 +331,34 @@
 					{:else if targetLocation != 'IN_PERSON'}
 						{#if canJoin}
 							<div class="mx-2 mt-2 rounded-md shadow-sm">
-								<a
-									href={joinUrl}
-									class="relative inline-flex justify-center rounded-md border-2 border-thatBlue-500
+								{#if discord.channelUrl}
+									<button
+										type="button"
+										on:click={() => (showDiscordLinksModal = true)}
+										class="relative inline-flex justify-center rounded-md border-2 border-thatBlue-500
                   bg-white px-4 py-2 text-sm font-medium
                   leading-5 text-thatBlue-500 transition
                   duration-150 ease-in-out
                   hover:bg-thatBlue-500 hover:text-white
                   focus:border-thatBlue-800 focus:bg-thatBlue-500
                   focus:text-white focus:outline-none focus:ring-thatBlue-500 active:bg-thatBlue-800">
-									<Icon data={signIn} class="-ml-1 mr-2 h-4 w-4 text-gray-400" />
-									<span>Join In</span>
-								</a>
+										<Icon data={signIn} class="-ml-1 mr-2 h-4 w-4 text-gray-400" />
+										<span>Join In</span>
+									</button>
+								{:else}
+									<a
+										href={joinUrl}
+										class="relative inline-flex justify-center rounded-md border-2 border-thatBlue-500
+                  bg-white px-4 py-2 text-sm font-medium
+                  leading-5 text-thatBlue-500 transition
+                  duration-150 ease-in-out
+                  hover:bg-thatBlue-500 hover:tes xt-white
+                  focus:border-thatBlue-800 focus:bg-thatBlue-500
+                  focus:text-white focus:outline-none focus:ring-thatBlue-500 active:bg-thatBlue-800">
+										<Icon data={signIn} class="-ml-1 mr-2 h-4 w-4 text-gray-400" />
+										<span>Join In</span>
+									</a>
+								{/if}
 							</div>
 						{:else}
 							<span class="mx-2 mt-2 rounded-md shadow-sm">
@@ -383,7 +405,7 @@
 				{:else}
 					<div>
 						<!-- Start Time -->
-						<p class="text-base text-gray-700  sm:mx-auto sm:text-lg md:text-xl lg:mx-0">
+						<p class="text-base text-gray-700 sm:mx-auto sm:text-lg md:text-xl lg:mx-0">
 							{#if durationInMinutes > 0}
 								{dayjs(startTime).format('dddd, MMMM D, YYYY - h:mm A z')}, for
 								{dayjs.duration(durationInMinutes, 'minutes').as('hours')}

--- a/src/_components/activities/Card.svelte
+++ b/src/_components/activities/Card.svelte
@@ -13,6 +13,7 @@
 	export let location;
 	export let dense = false;
 	export let status;
+	export let discord;
 
 	// 3rd party
 	import { onMount, getContext } from 'svelte';
@@ -41,7 +42,9 @@
 
 	import { Tag } from '$elements';
 	import CardLink from './CardLink.svelte';
+	import CardButton from './CardButton.svelte';
 	import favorites, { toggle } from '$lib/stores/favorites';
+	import DiscordLinksModal from './DiscordLinksModal.svelte';
 
 	dayjs.extend(isBetween);
 	dayjs.extend(isSameOrAfter);
@@ -135,8 +138,12 @@
 	const userProfileImage = host.profileImage || config.defaultProfileImage;
 	const srcset = buildImageSrc(userProfileImage, ['96']);
 	const joinUrl = getSessionUrl();
+	let showDiscordLinksModal = false;
 </script>
 
+{#if showDiscordLinksModal === true}
+	<DiscordLinksModal {discord} bind:showModal={showDiscordLinksModal} />
+{/if}
 {#if dense}
 	<div
 		class="mb-2 flex h-full w-full flex-col"
@@ -311,7 +318,7 @@
 								<div class="flex h-full">
 									{#if targetLocation === 'IN_PERSON'}
 										<div
-											class="flex w-full justify-center space-x-8 rounded-br-lg  bg-that-blue py-2 text-xs font-medium  text-white">
+											class="flex w-full justify-center space-x-8 rounded-br-lg bg-that-blue py-2 text-xs font-medium text-white">
 											<div class="flex justify-center space-x-2">
 												<Icon data={user} class="h-4 w-4" />
 												<span>In-Person</span>
@@ -324,7 +331,14 @@
 										</div>
 									{:else if canJoin}
 										<div class="-ml-px flex flex-1 basis-0 border-l pl-1 text-center">
-											<CardLink href={joinUrl} icon={signIn} text={'Join In'} />
+											{#if discord.channelUrl}
+												<CardButton
+													on:click={() => (showDiscordLinksModal = true)}
+													icon={signIn}
+													text={'Join In'} />
+											{:else}
+												<CardLink href={joinUrl} icon={signIn} text={'Join In'} />
+											{/if}
 										</div>
 									{:else}
 										<div class="-ml-px flex flex-1 border-l pl-1 text-center">
@@ -405,7 +419,7 @@
 			{#if status === 'CANCELLED'}
 				<div class="flex items-center justify-center">
 					<img
-						class="lazyload relative h-28 "
+						class="lazyload relative h-28"
 						alt="canceled session"
 						src="/images/canceled-stamp.svg" />
 				</div>
@@ -506,7 +520,7 @@
 					{#if targetLocation === 'IN_PERSON'}
 						<div class="-ml-px flex w-0 flex-1">
 							<div
-								class="flex w-full justify-center space-x-8 rounded-bl-lg rounded-br-lg border border-transparent bg-that-blue py-2 text-xs font-medium  text-white">
+								class="flex w-full justify-center space-x-8 rounded-bl-lg rounded-br-lg border border-transparent bg-that-blue py-2 text-xs font-medium text-white">
 								<div class="flex justify-center space-x-2">
 									<Icon data={user} class="h-4 w-4" />
 									<span>In-Person</span>
@@ -520,7 +534,14 @@
 						</div>
 					{:else if canJoin}
 						<div class="-ml-px flex w-0 flex-1">
-							<CardLink href={joinUrl} icon={signIn} text={'Join In'} />
+							{#if discord.channelUrl}
+								<CardButton
+									on:click={() => (showDiscordLinksModal = true)}
+									icon={signIn}
+									text={'Join In'} />
+							{:else}
+								<CardLink href={joinUrl} icon={signIn} text={'Join In'} />
+							{/if}
 						</div>
 					{:else}
 						<div class="-ml-px flex w-0 flex-1">

--- a/src/_components/activities/CardButton.svelte
+++ b/src/_components/activities/CardButton.svelte
@@ -1,0 +1,17 @@
+<script>
+	import Icon from 'svelte-awesome';
+
+	export let icon;
+	export let text;
+</script>
+
+<button
+	type="button"
+	on:click
+	class="focus:ring-blue relative -mr-px inline-flex flex-1 basis-0 items-center justify-center
+  rounded-bl-lg border border-transparent py-2 text-xs font-medium
+  leading-4 text-gray-700 transition duration-150
+  ease-in-out hover:text-gray-300 focus:z-10 focus:border-blue-300 focus:outline-none">
+	<Icon data={icon} class="h-4 w-4" />
+	<span class="ml-3">{text}</span>
+</button>

--- a/src/_components/activities/DiscordLinksModal.svelte
+++ b/src/_components/activities/DiscordLinksModal.svelte
@@ -1,0 +1,23 @@
+<script>
+	export let discord;
+	export let showModal = false;
+
+	import { Action as ActionModal } from '$elements/modals';
+	import { Standard as StandardLink } from '$elements/links';
+	import { clickOutside } from '$elements/actions';
+</script>
+
+<ActionModal
+	title="Leaving THAT.us site"
+	text="THAT.us Activities are hosted on <span class='font-bold'>Discord</span>. Please use the
+appropriate link below to get started.">
+	<div
+		class="flex justify-center space-x-6"
+		use:clickOutside
+		on:click_outside={() => (showModal = false)}>
+		<StandardLink href={discord.channelUrl} target="_blank" on:click={() => (showModal = false)}
+			>Go as Discord Member</StandardLink>
+		<StandardLink href={discord.inviteUrl} target="_blank" on:click={() => (showModal = false)}
+			>Go using Discord Invite</StandardLink>
+	</div>
+</ActionModal>

--- a/src/_components/activities/List.svelte
+++ b/src/_components/activities/List.svelte
@@ -193,7 +193,8 @@
 			'targetLocation',
 			'location',
 			'eventId',
-			'status'
+			'status',
+			'discord'
 		]);
 	}
 </script>

--- a/src/_dataSources/api.that.tech/sessions.js
+++ b/src/_dataSources/api.that.tech/sessions.js
@@ -27,6 +27,12 @@ const coreSessionFields = `
 			isOnline
 			url
 		}
+		discord {
+			channelUrl
+			inviteUrl
+			guildScheduledEventUrl
+			guildScheduledEventInviteUrl
+		}
 		agenda
 		longDescription
 		prerequisites

--- a/src/_elements/links/Standard.svelte
+++ b/src/_elements/links/Standard.svelte
@@ -5,6 +5,7 @@
 </script>
 
 <a
+	on:click
 	{href}
 	{rel}
 	{target}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -110,7 +110,7 @@
 	}
 
 	:global(.prose a:hover) {
-		color: #f3f4f6;
+		color: #ff834d;
 	}
 
 	:global(.lineBreaks) {

--- a/src/routes/support/joining-an-activity/+page.svelte
+++ b/src/routes/support/joining-an-activity/+page.svelte
@@ -27,11 +27,15 @@
 		<div class="prose prose-lg mx-auto text-gray-500">
 			<p>
 				<strong>Click the join button.</strong> Yes, it's just THAT simple. The join button enables itself
-				5 minutes before the scheduled start time (in your timezone0) and will remain active for the
-				duration of the activity. THAT works in any browser and you just need to enable your webcam and
-				microphone. We do require everyone to log in before joining any Activity. Your mic will always
-				be muted by default and your camera will be enabled. Activities are currently limited to 100
-				concurrent attendees.
+				5 minutes before the scheduled start time (in your timezone) and will remain active for the duration
+				of the activity.
+			</p>
+			<p>
+				THAT utilizes Discord, via <a href="https://discord.gg/annje7TBG8"> THAT Discord</a>, which
+				works in any browser or the Discord client, and you just need to enable your webcam and
+				microphone. We do require everyone to log in before joining any Activity. Your mic will
+				always be muted by default and your camera will be enabled. Activities are currently limited
+				to 100 concurrent attendees.
 			</p>
 
 			<div class="scale-75 transform text-center">
@@ -48,7 +52,6 @@
 			</p>
 			<ul>
 				<li>Always be nice.</li>
-				<li>Raise hand to speak.</li>
 				<li>Mute yourself when not speaking.</li>
 				<li>Speak clearly so others can hear you.</li>
 				<li>Create space so others can speak.</li>

--- a/src/routes/support/staying-up-to-date/+page.svelte
+++ b/src/routes/support/staying-up-to-date/+page.svelte
@@ -64,10 +64,7 @@
 			<p>
 				<a href="/activities/">The Activity Board</a>
 				as we call it, is your main place to find out what's up next. It will always show all Activities
-				from today looking forward. You can also find
-				<strong class="italic">all</strong>
-				Activities
-				<a href="/events/thatUs/">here</a>.
+				from today looking forward.
 			</p>
 
 			<p>


### PR DESCRIPTION
## v3.16.0

Adds modal when joining online activity to inform user is leaving THAT.us and heading to Discord.
Retained `joinUrl` links. If a discord link isn't available on a session, the joinUrl will be used instead.