### PR TITLE
Chore/sentry deny urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "that-us",
-	"version": "3.16.0",
+	"version": "3.16.1",
 	"description": "THAT.us website",
 	"main": "index.js",
 	"type": "module",

--- a/src/_utils/config.public.js
+++ b/src/_utils/config.public.js
@@ -48,7 +48,15 @@ export const securityConfig = () => {
 
 export const logging = {
 	dsn: 'https://15d4b436dc0a4366a0ac388c65772926@o235190.ingest.sentry.io/5357492',
-	environment: env.PUBLIC_VERCEL_ENV
+	environment: env.PUBLIC_VERCEL_ENV,
+	denyUrls: [
+		'/cdn-cgi/zaraz/',
+		'https://js.zi-scripts.com/', // zoom info
+		/^chrome:\/\//i,
+		/^https?:\/\/(?:\w+\.)?cloudflareinsights\.com\//,
+		/^https?:\/\/(?:\w+\.)?gstatic\.com\//,
+		'bpm:///conversations-embed'
+	]
 };
 
 export const debug = {

--- a/src/hooks.client.js
+++ b/src/hooks.client.js
@@ -5,11 +5,13 @@ import { logging } from '$utils/config.public';
 // `replaysSessionSampleRate` and `replaysOnErrorSampleRate` options.
 Sentry.init({
 	dsn: logging.dsn,
+	attachStacktrace: true,
 	tracesSampleRate: 1,
 	replaysSessionSampleRate: 0.1,
 	replaysOnErrorSampleRate: 1,
 	integrations: [new Sentry.Replay()],
-	environment: logging.environment
+	environment: logging.environment,
+	denyUrls: logging.denyUrls
 });
 
 export const handleError = Sentry.handleErrorWithSentry();

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -15,8 +15,10 @@ const { clientSecret, secret } = privateConfig();
 
 Sentry.init({
 	dsn: logging.dsn,
+	attachStacktrace: true,
 	environment: logging.environment,
-	tracesSampleRate: 1
+	tracesSampleRate: 1,
+	denyUrls: logging.denyUrls
 });
 
 const loginRedirectPaths = [


### PR DESCRIPTION
## v3.16.1

Add two parameters to sentry init: `attachStacktrace: true` and `denyUrls: []`

`attachStacktrace` ([ref](https://docs.sentry.io/platforms/javascript/configuration/options/#attach-stacktrace)) automatically attaches stack traces to all messages, not only exceptions.  
`denyUrls` ([ref](https://docs.sentry.io/platforms/javascript/configuration/options/#deny-urls)) sets an array of urls matches to ignore. Errors originating from these urls, e.g. zaraz, will not be logged in Sentry, cleaning up the noise. 