### PR TITLE
fix: updating sentry api calls

### DIFF
--- a/src/hooks.client.js
+++ b/src/hooks.client.js
@@ -6,12 +6,10 @@ import { logging } from '$utils/config.public';
 Sentry.init({
 	dsn: logging.dsn,
 	attachStacktrace: true,
-	tracesSampleRate: 1,
-	replaysSessionSampleRate: 0.1,
-	replaysOnErrorSampleRate: 1,
-	integrations: [new Sentry.Replay()],
 	environment: logging.environment,
-	denyUrls: logging.denyUrls
+	denyUrls: logging.denyUrls,
+	enableTracing: false,
+	tracesSampleRate: 0
 });
 
 export const handleError = Sentry.handleErrorWithSentry();

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -17,8 +17,9 @@ Sentry.init({
 	dsn: logging.dsn,
 	attachStacktrace: true,
 	environment: logging.environment,
-	tracesSampleRate: 1,
-	denyUrls: logging.denyUrls
+	denyUrls: logging.denyUrls,
+	enableTracing: false,
+	tracesSampleRate: 0
 });
 
 const loginRedirectPaths = [


### PR DESCRIPTION
turning off sentry's performance tracking
